### PR TITLE
feat(agents): ship starter AI skills

### DIFF
--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -1,6 +1,6 @@
 # Python Project Template Usage Guide
 
-This template provides a complete Python project setup with CI/CD, quality tools, documentation, and Claude AI configuration.
+This template provides a complete Python project setup with CI/CD, quality tools, documentation, and shared Claude/Codex AI-skill configuration.
 
 ## Quick Start
 
@@ -62,17 +62,26 @@ python-project-template/
 │   └── dependabot.yml             # Dependency updates
 ├── .claude/
 │   └── settings.local.json        # Claude Code permissions
+├── ai-skills/
+│   ├── feature-delivery/          # Starter issue-delivery skill
+│   └── feature-design/            # Starter issue-design skill + helper assets
 ├── config/
 │   └── config.example.yaml        # Configuration template
 ├── docs/
 │   ├── INDEX.md                   # Documentation hub
+│   ├── AI_SKILLS.md               # AI skills source/deploy documentation
 │   ├── SETUP.md                   # Installation guide
 │   ├── ARCHITECTURE.md            # Technical design
 │   ├── CI.md                      # CI/CD documentation
 │   ├── BRANCH_PROTECTION.md       # Branch protection documentation
 │   └── planning/
 │       └── TASK_MANAGEMENT.md     # Task tracking
+├── infra/
+│   └── ai-skills/
+│       ├── deploy_ai_skills.yml   # Dual-deploy playbook for AI skills
+│       └── templates/             # Jinja templates for Claude/Codex rendering
 ├── scripts/
+│   ├── deploy_ai_skills.sh        # Local AI skills deploy wrapper
 │   └── github/
 │       ├── branch-protection-config.json  # Protection rules config
 │       └── setup-branch-protection.sh     # Setup script
@@ -106,10 +115,11 @@ python-project-template/
 - **Security job**: bandit and pip-audit scanning
 - **Config validation**: YAML and Python syntax checks
 
-### Claude AI Workflows (Optional)
+### AI Agent Workflows (Optional)
 
 - **claude.yml**: Automation triggered by `@claude` mentions in issues/PRs
 - **claude-code-review.yml**: Code review via `/claude-review` comment
+- **ai-skills/**: Canonical AI skills source rendered to both Claude and Codex
 
 > **Note**: These require a `CLAUDE_CODE_OAUTH_TOKEN` secret in your repository.
 
@@ -148,11 +158,26 @@ See `docs/BRANCH_PROTECTION.md` for full documentation.
 - `CLAUDE.md` - AI assistant guidance for Claude Code
 - `README.md` - User-facing project documentation
 - `docs/INDEX.md` - Central documentation hub
+- `docs/AI_SKILLS.md` - Canonical AI skills structure and deploy workflow
 - `docs/CI.md` - CI/CD pipeline documentation
 - `docs/SETUP.md` - Installation and configuration guide
 - `docs/ARCHITECTURE.md` - Technical architecture (placeholder)
 - `docs/BRANCH_PROTECTION.md` - Branch protection rules documentation
 - `docs/planning/TASK_MANAGEMENT.md` - Development task tracking
+
+### AI Skills
+
+The template now ships two starter AI skills:
+- `feature-delivery` for end-to-end issue implementation workflow
+- `feature-design` for turning rough requests into implementation-ready GitHub issues
+
+Deploy both to Claude and Codex with:
+
+```bash
+./scripts/deploy_ai_skills.sh
+```
+
+See `docs/AI_SKILLS.md` for the canonical layout, rendering model, and troubleshooting guidance.
 
 ## Post-Setup Steps
 

--- a/ai-skills/feature-delivery/instructions.md
+++ b/ai-skills/feature-delivery/instructions.md
@@ -1,0 +1,115 @@
+# Feature Delivery
+
+Use this skill for issue-driven implementation work when the task is to deliver one or several GitHub issues end to end.
+
+Read first:
+- `AGENTS.md`
+- `README.md`
+- `docs/INDEX.md`
+- `docs/AGENT_CONTEXT.md` when present
+
+Use the GitHub workflow as the default delivery path for functional changes.
+If the user explicitly requests a direct push to `main` without a PR, treat that as an override to this default workflow rather than inferring a PR anyway.
+
+Workflow:
+1. Start on `main` and pull `origin/main`.
+2. If the work is tied to a GitHub issue, read the issue with the GitHub CLI before implementing:
+   - use `gh issue view <number>` to read the issue body
+   - use `gh issue view <number> --comments` when comments or clarifications may affect scope
+   - do not rely only on branch names, PR titles, or secondhand summaries when the issue itself is available
+3. Create a dedicated branch using repo naming rules:
+   - `feature/...` for features
+   - `fix/...` for bug fixes
+   - `docs/...` for docs-only work
+   - include the GitHub issue number near the front when relevant, for example `feature/123-api-cleanup`
+   - a dedicated worktree is optional when it helps keep the primary checkout clean
+4. Implement the issue scope in that branch or worktree.
+5. Document architecture usage and explain how the change works.
+6. Update docs and Mermaid/context docs when schema, API surface, control flow, or data flow changes.
+7. Run targeted tests, then `pre-commit`, and fix failures before commit.
+8. Commit with a conventional message, push the branch, and open a PR that closes the issue.
+9. Wait for CI and fix failures until green.
+10. Once CI is green, request an external review by adding `@codex review` or the repository's equivalent review trigger on the pull request.
+11. While waiting for the review to arrive, review your own PR and leave a self-review comment that covers the main change, primary risks, and any test or verification gaps you still see.
+   - scale self-review depth to implementation risk
+   - for high-risk changes such as background automation, queue processing, task lifecycle, API or CLI concurrency, locks, retries, sync high-water marks, stale-run cleanup, or cancellation paths, do not stop at happy-path behavior and basic observability
+   - in high-risk self-review, explicitly challenge failure modes such as:
+     - partial success followed by a later side-effect failure
+     - retry or idempotency after state or high-water marks advance
+     - cancellation at awaited boundaries, including `asyncio.CancelledError`
+     - stale state versus long-running live work
+     - read-before-act races in multi-process deployments
+     - interaction between automation, API, CLI, and worker entry points
+     - queue row state transitions and terminal-update preconditions
+     - lock acquisition and release behavior, including pool starvation and request shutdown
+   - if repeated risks fall into the same category, pause and audit the whole category before asking for another review
+12. Wait up to five minutes for the external review to arrive. If no review is present after five minutes, skip the external review requirement and continue the process.
+13. Read the review carefully and participate in the feedback loop:
+   - inline review comments are not visible in `gh pr view --json reviews,comments`; that command is not a sufficient review audit
+   - always audit review threads with GraphQL before deciding there are no actionable findings:
+     ```bash
+     gh api graphql \
+       -f owner=<owner> \
+       -f repo=<repo> \
+       -F number=<pr-number> \
+       -f query='query($owner:String!, $repo:String!, $number:Int!) {
+         repository(owner:$owner, name:$repo) {
+           pullRequest(number:$number) {
+             reviewThreads(first:100) {
+               nodes {
+                 id
+                 isResolved
+                 isOutdated
+                 comments(first:20) {
+                   nodes {
+                     id
+                     author { login }
+                     body
+                     path
+                     line
+                     url
+                   }
+                 }
+               }
+             }
+           }
+         }
+       }'
+     ```
+   - treat any review-thread comment with an actionable finding as requiring an inline reply, even if the top-level review body is generic
+   - as soon as a review lands, audit the review threads and reply in-thread before starting the next round of fixes
+   - do not treat review comments as a private TODO list while leaving the GitHub threads unanswered
+   - reply to each review comment directly as a reply to that comment thread, not as a new top-level PR comment
+   - do this for every review round, including follow-up reviews after additional commits
+   - after each new review lands, explicitly audit the PR review threads and identify any new unresolved findings before deciding the PR is ready
+   - before writing more code for review feedback, make sure every current finding already has an inline reply with a clear disposition such as fixed, investigating, deferred, declined, or not applicable
+   - after replying inline, use this cadence for review feedback:
+     - receive the review batch
+     - reply inline immediately
+     - pause
+     - do a full self-audit across the whole class of bugs
+     - fix the class, not just the exact comment
+     - push one coherent hardening commit
+     - request review again
+   - avoid a tight loop of small fix, review, small fix, review
+   - when several findings point at one risk class, consolidate the fix so the next review validates the model rather than discovering the next adjacent failure
+   - when a finding is fixed, reply in-thread with the resolution and the commit that addressed it
+   - when a finding is deferred or declined, reply in-thread with the reason so the thread has an explicit disposition
+   - if the feedback is reasonable, prefer fixing it in the same PR, rerun validation, and push updates
+   - only defer review feedback to a follow-up when there is a good reason not to expand the current PR, such as materially increased scope, materially increased complexity, a riskier change, or a case that needs more careful design work
+   - if the feedback should be deferred, create a follow-up issue and explain why it is not being fixed in the current PR
+   - if the feedback is not applicable, document why in the PR so the resolution is explicit
+14. After responding to review and your self-review findings, leave the required decision comment describing what was fixed now, deferred, or not done.
+15. If a follow-up issue is needed, create it with a title starting `[followup]`.
+16. Merge the PR.
+17. Return to `main`, pull fresh `origin/main`, clean up the feature branch or worktree, and update any session notes if the repository uses them.
+
+Guardrails:
+- PR by default; direct push only when the user explicitly asks for it.
+- Never skip `pre-commit` and never use `--no-verify`.
+- Never change the coverage target without an explicit user request.
+- Do not merge immediately after CI goes green; request external review, wait up to five minutes, and handle the feedback loop before merge. If no review arrives within five minutes, skip it and continue.
+- The implementing agent must still do its own self-review even when external review is requested.
+- Once review lands, reply in-thread before diving into more implementation work.
+- Before merge, run the GraphQL review-thread audit above and verify that every review finding has an inline reply and an explicit disposition, especially after follow-up commits and re-reviews.
+- Before merge, do not rely on top-level PR comments or `gh pr view --json reviews,comments` as proof that review feedback was handled.

--- a/ai-skills/feature-delivery/skill.yaml
+++ b/ai-skills/feature-delivery/skill.yaml
@@ -1,0 +1,7 @@
+name: feature-delivery
+description: Use when delivering GitHub issues end to end through branch, tests, PR, CI, review, merge, and cleanup.
+codex:
+  interface:
+    display_name: Feature Delivery
+    short_description: Implement GitHub issues end to end
+    default_prompt: Use $feature-delivery to deliver a GitHub issue end to end.

--- a/ai-skills/feature-design/instructions.md
+++ b/ai-skills/feature-design/instructions.md
@@ -1,0 +1,111 @@
+# Feature Design
+
+Use this skill when the task is not to implement a feature yet, but to design it well enough that developers can execute it cleanly.
+
+Read first:
+- `AGENTS.md`
+- `README.md`
+- `docs/INDEX.md`
+- `docs/AGENT_CONTEXT.md` when present
+- `references/github_issue_mockup_screenshots.md` when the task includes mockup screenshots or GitHub issue image uploads
+
+Default stance:
+- act like a system architect translating product intent into an implementation-ready engineering plan
+- keep solutions as simple as possible, but add complexity where the problem genuinely needs it
+- do not fake certainty; if important requirements or tradeoffs are unclear, ask for clarification
+
+Use this skill for:
+- turning a rough feature request into a concrete design
+- refining a draft GitHub issue into an implementation-ready issue body
+- creating a new GitHub issue when no issue exists yet
+- reviewing references such as related issues, PRs, screenshots, docs, or code paths to shape the design
+- creating lightweight HTML and CSS mockups for proposed web UI changes when a visual guide would reduce ambiguity
+- capturing screenshots from those mockups or from browser tooling when available so the issue can include concrete visual direction
+- using authenticated browser automation when available to open local mockups, capture screenshots, and upload those screenshots directly into GitHub issues or PRs
+- writing phased implementation plans, validation plans, and explicit open questions before coding starts
+
+Workflow:
+1. Start by understanding the request:
+   - identify the user problem, desired outcome, and any stated constraints
+   - note references provided by the requester such as issue numbers, PRs, screenshots, pages, or files
+2. Gather project context before proposing solutions:
+   - read `AGENTS.md`, `README.md`, `docs/INDEX.md`, and `docs/AGENT_CONTEXT.md` when present
+   - read only the relevant docs and code paths needed for the feature
+   - if a GitHub issue already exists, read it with `gh issue view <number>`
+   - use `gh issue view <number> --comments` when comments may affect scope or decisions
+   - if related PRs or issues are referenced, read those too before finalizing the design
+3. Clarify uncertainty early:
+   - if important requirements, tradeoffs, or acceptance criteria are unclear, ask the requester before locking the design
+   - if screenshots or visual references are provided, inspect them rather than guessing
+4. Design the feature at the right level:
+   - define the problem and why the change is needed
+   - describe the proposed user-facing behavior
+   - identify the affected architecture, APIs, data flow, storage, UI states, background jobs, or operational paths
+   - call out non-goals when they help keep the scope controlled
+   - prefer the smallest design that solves the actual problem cleanly
+   - when the request includes a meaningful UI change, decide whether a mockup or screenshot would make the plan clearer
+5. Turn the design into an implementation plan developers can execute:
+   - break the work into ordered steps or phases
+   - include validation expectations such as tests, docs updates, migration handling, and operational verification when relevant
+   - surface risks, edge cases, follow-ups, and rollout concerns explicitly
+   - for high-risk work, split the design into explicit invariants before coding
+   - high-risk work includes background automation, queues, schedulers, workers, sync pipelines, task lifecycle, API or CLI concurrency, locks, retries, stale cleanup, cancellation-sensitive flows, schema migrations, and operational control paths
+   - useful invariants include:
+     - no overlapping execution across all entry points that can start the same work
+     - no synced or externally observed delta can be lost before downstream enqueue or persistence
+     - no stale worker or run can terminally update state after a newer pending trigger exists
+     - cancellation never loses claimed work
+     - stale cleanup never kills live long-running work
+     - locks must not consume the same constrained resource pool needed by protected work
+   - for these features, include a failure-mode matrix and validation plan that directly tests the invariants
+   - if UI mockups are created, describe how they map to the implementation plan rather than leaving them as disconnected visuals
+6. Write the GitHub issue:
+   - if an issue already exists, update its description so the issue body becomes the current source of truth
+   - if no issue exists, create a new issue with a clear title and full body
+   - preserve useful existing context instead of overwriting it carelessly
+   - when a mockup exists and browser automation is available, prefer opening the mockup in the browser, taking screenshots, and uploading those images into the GitHub issue or PR instead of pasting raw HTML or CSS
+7. Before finishing:
+   - if there are unresolved design gaps, include explicit open questions and ask the requester for feedback
+   - make sure the issue is specific enough that an implementing agent can pick it up without needing to rediscover the architecture
+
+UI mockup guidance:
+- Use mockups when the request changes web-app layout, controls, information hierarchy, empty states, detail pages, dialogs, or operator workflows.
+- Prefer lightweight HTML and CSS mockups over heavy implementation when the goal is visual clarification rather than shipping UI code.
+- If browser or Playwright-style tooling is available, use it to inspect the current UI and capture screenshots of mockups or live references.
+- Store GitHub-authenticated Playwright browser state at `.playwright-mcp/auth/github-storage-state.json` so the browser session can be reused for issue and PR updates without committing secrets to the repo.
+- If authenticated GitHub access is available in that browser session, complete the loop there: open the local mockup, capture the screenshots, save them, then edit the GitHub issue or PR and upload the images so they render inline.
+- When browser MCP is not sufficient for reliable click and file-upload automation, use `scripts/github_mockup_issue_assets.py` from this skill. It captures selector-based screenshots from a local mockup, uploads them through the authenticated GitHub session, and writes both a manifest and a Markdown snippet for the issue body.
+- The proven issue-upload path is the issue or PR comment form. Use the textarea selector `textarea[placeholder="Use Markdown to format your comment"]` and the `Add files` button to upload images.
+- GitHub inserts uploaded images into the textarea as HTML `<img ... src="https://github.com/user-attachments/assets/...">` tags rather than Markdown. Extract the `user-attachments` URLs and use those URLs in the main issue body or PR description.
+- Prefer updating the main issue body after the assets exist instead of leaving the screenshots only in a comment. Replace raw mockup source with concise captions plus the uploaded images.
+- Do not treat GitHub issue bodies as a place to paste full mockup source; GitHub images plus concise Markdown context are the preferred deliverable.
+- Keep mockups close to the existing product visual language unless the requester asks for a larger redesign.
+- Treat mockups as design aids: they should clarify states, actions, and structure, not silently expand feature scope.
+
+Preferred issue structure:
+- Problem
+- Goal
+- Non-goals
+- Current context
+- Proposed design
+- Invariants for high-risk work
+- Failure-mode matrix for high-risk work
+- Visual guide or mockups
+- Implementation plan
+- Validation
+- Risks or edge cases
+- Open questions
+
+Guardrails:
+- Design from the existing architecture instead of inventing a parallel system without reason.
+- If the feature changes schema, API surface, control flow, or data flow, say so explicitly in the plan.
+- If the feature affects operations, deployment, worker behavior, CI, or observability, include those consequences in the issue body.
+- If the feature includes UI work and a mockup would meaningfully reduce ambiguity, include a visual guide in the issue body or issue comments.
+- If the request is still too ambiguous after reading the references, stop and ask for clarification rather than producing a vague plan.
+- Do not jump into implementation when the task is clearly design and planning.
+
+Output expectations:
+- Produce an implementation-ready GitHub issue body, not just loose brainstorming notes.
+- Make tradeoffs and assumptions explicit.
+- When a phased rollout is safer than a single large change, say so and structure the plan accordingly.
+- When mockups are included, explain what they are intended to communicate and what is still left for implementation judgment.

--- a/ai-skills/feature-design/references/github_issue_mockup_screenshots.md
+++ b/ai-skills/feature-design/references/github_issue_mockup_screenshots.md
@@ -1,0 +1,81 @@
+# GitHub Issue Mockup Screenshots
+
+Use this workflow when a feature-design task needs local HTML or CSS mockups turned into screenshots and then embedded into a GitHub issue or pull request.
+
+## When to use this
+
+Use it when:
+- a visual guide is useful, but browser automation cannot reliably click, type, or upload files
+- you already have a local prototype and want a repeatable upload path using authenticated GitHub browser state
+- the issue or PR should contain uploaded screenshots instead of raw mockup source
+
+## Preconditions
+
+- Run from the repository root.
+- Use a Python environment that has Playwright available.
+- GitHub browser auth state should exist at `.playwright-mcp/auth/github-storage-state.json` unless you pass a different `--auth-state`.
+
+## Preferred helper
+
+Use:
+
+```bash
+python ai-skills/feature-design/scripts/github_mockup_issue_assets.py \
+  --repo owner/name \
+  --issue 123 \
+  --mockup-url file:///absolute/path/to/mockup.html \
+  --selectors selectors.txt \
+  --output .playwright-mcp/issue-123-assets
+```
+
+What the helper does:
+- opens the local mockup
+- captures one PNG per selector
+- opens the target GitHub issue or PR
+- uploads the PNGs through the GitHub comment form
+- extracts the generated `https://github.com/user-attachments/assets/...` URLs
+- writes:
+  - `<output>/manifest.json`
+  - `<output>/snippet.md`
+
+`selectors.txt` should contain one CSS selector per line.
+Blank lines and lines starting with `#` are ignored.
+If a line is written as `slug=selector`, the slug is used for the output filename.
+
+## Reliable GitHub selectors
+
+The most reliable selectors are:
+- comment textarea: `textarea[placeholder="Use Markdown to format your comment"]`
+- upload trigger: button with accessible name matching `Add files`
+
+Important behavior:
+- after upload, GitHub inserts HTML `<img>` tags into the textarea, not Markdown image syntax
+- the durable part is the `src` URL under `https://github.com/user-attachments/assets/...`
+- use those asset URLs in the main issue body or PR description
+
+## Recommended post-upload step
+
+After the helper writes `snippet.md`, update the main issue or PR body so the screenshots are the source of truth:
+- keep the design narrative and implementation plan
+- remove raw prototype HTML or CSS blocks from the body
+- replace them with the generated image section and short captions
+
+Typical CLI pattern:
+
+```bash
+tmp_body="$(mktemp)"
+gh issue view 123 --json body -q .body > "$tmp_body"
+# Edit the body file to replace the mockup-source section with the generated Markdown.
+gh issue edit 123 --body-file "$tmp_body"
+```
+
+## Manifest pattern
+
+The helper records:
+- the target URL
+- the original mockup URL
+- each selector
+- the local PNG path
+- the uploaded asset URL
+
+That manifest makes it easy to audit which screenshot maps to which selector and uploaded image.

--- a/ai-skills/feature-design/scripts/github_mockup_issue_assets.py
+++ b/ai-skills/feature-design/scripts/github_mockup_issue_assets.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Capture mockup screenshots and upload them into a GitHub issue or PR."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+COMMENT_TEXTAREA_SELECTOR = 'textarea[placeholder="Use Markdown to format your comment"]'
+ATTACHMENT_URL_RE = re.compile(r"https://github\.com/user-attachments/assets/[0-9a-fA-F-]+")
+DEFAULT_AUTH_STATE = Path(".playwright-mcp/auth/github-storage-state.json")
+DEFAULT_BROWSER_PATH = Path("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+
+
+@dataclass(frozen=True)
+class SelectorSpec:
+    """Describe one screenshot to capture from the mockup page."""
+
+    slug: str
+    selector: str
+
+
+@dataclass(frozen=True)
+class CapturedImage:
+    """Represent one captured image and its metadata."""
+
+    slug: str
+    selector: str
+    path: Path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Capture selector-based mockup screenshots and upload them to a GitHub issue or pull request."
+    )
+    parser.add_argument("--repo", required=True, help="Repository in owner/name form")
+    target_group = parser.add_mutually_exclusive_group(required=True)
+    target_group.add_argument("--issue", type=int, help="GitHub issue number")
+    target_group.add_argument("--pr", type=int, help="GitHub pull request number")
+    parser.add_argument("--mockup-url", required=True, help="Local file:// URL or HTTP URL for the mockup")
+    parser.add_argument(
+        "--selectors",
+        required=True,
+        help="Path to a newline-separated selector list file. Supports optional slug=selector lines.",
+    )
+    parser.add_argument(
+        "--auth-state",
+        default=str(DEFAULT_AUTH_STATE),
+        help="Playwright storage state with an authenticated GitHub session",
+    )
+    parser.add_argument("--output", required=True, help="Output directory for screenshots and metadata")
+    parser.add_argument(
+        "--browser-path",
+        default=str(DEFAULT_BROWSER_PATH),
+        help="Preferred browser executable path. Falls back to Playwright Chromium when absent.",
+    )
+    parser.add_argument("--headless", action="store_true", help="Run the browser headlessly")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=90,
+        help="Timeout for upload completion and selector waits",
+    )
+    return parser.parse_args()
+
+
+def build_target_url(repo: str, issue: int | None, pr: int | None) -> str:
+    """Build the GitHub target URL."""
+    if issue is not None:
+        return f"https://github.com/{repo}/issues/{issue}"
+    if pr is not None:
+        return f"https://github.com/{repo}/pull/{pr}"
+    raise ValueError("Either issue or pr must be provided.")
+
+
+def normalize_slug(raw: str) -> str:
+    """Normalize free-form text into a filesystem-safe slug."""
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", raw.strip()).strip("-").lower()
+    if not slug:
+        raise ValueError(f"Could not derive a slug from {raw!r}.")
+    return slug
+
+
+def derive_slug_from_selector(selector: str, index: int) -> str:
+    """Derive a stable slug when the selector file does not provide one."""
+    tokens = [token for token in re.split(r"[^a-zA-Z0-9]+", selector) if token]
+    if tokens:
+        joined = "-".join(tokens[:4])
+        return normalize_slug(f"{index:02d}-{joined}")
+    return f"{index:02d}-shot"
+
+
+def parse_selector_line(raw_line: str, index: int) -> SelectorSpec | None:
+    """Parse one selector file line into a selector spec."""
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        return None
+    explicit_slug_match = re.match(r"^(?P<slug>[A-Za-z0-9_-]+)=(?P<selector>.+)$", line)
+    if explicit_slug_match:
+        slug = normalize_slug(explicit_slug_match.group("slug"))
+        selector = explicit_slug_match.group("selector").strip()
+        selector = selector.strip()
+        if not selector:
+            raise ValueError(f"Missing selector for line: {raw_line!r}")
+        return SelectorSpec(slug=slug, selector=selector)
+    return SelectorSpec(slug=derive_slug_from_selector(line, index), selector=line)
+
+
+def load_selectors(selector_file: Path) -> list[SelectorSpec]:
+    """Load selector specs from disk."""
+    specs: list[SelectorSpec] = []
+    for index, raw_line in enumerate(selector_file.read_text(encoding="utf-8").splitlines(), start=1):
+        spec = parse_selector_line(raw_line, index)
+        if spec is not None:
+            specs.append(spec)
+    if not specs:
+        raise ValueError(f"No selectors found in {selector_file}.")
+    return specs
+
+
+def render_snippet(images: Sequence[CapturedImage], asset_urls: Sequence[str]) -> str:
+    """Render the Markdown snippet to embed into an issue or PR body."""
+    lines = ["## Visual Guide", ""]
+    for image, asset_url in zip(images, asset_urls):
+        lines.append(f"### `{image.slug}`")
+        lines.append(f"Selector: `{image.selector}`")
+        lines.append("")
+        lines.append(f"![{image.slug}]({asset_url})")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def capture_screenshots(
+    page: Any,
+    mockup_url: str,
+    selectors: Sequence[SelectorSpec],
+    output_dir: Path,
+) -> list[CapturedImage]:
+    """Capture one screenshot per selector."""
+    page.goto(mockup_url, wait_until="networkidle")
+    captured: list[CapturedImage] = []
+    for selector_spec in selectors:
+        locator = page.locator(selector_spec.selector).first
+        locator.wait_for(state="visible", timeout=30_000)
+        image_path = output_dir / f"{selector_spec.slug}.png"
+        locator.screenshot(path=str(image_path))
+        captured.append(CapturedImage(slug=selector_spec.slug, selector=selector_spec.selector, path=image_path))
+    return captured
+
+
+def upload_images(page: Any, target_url: str, images: Sequence[CapturedImage], timeout_seconds: int) -> list[str]:
+    """Upload images via the GitHub comment form and return attachment URLs."""
+    page.goto(target_url, wait_until="domcontentloaded")
+    textarea = page.locator(COMMENT_TEXTAREA_SELECTOR).first
+    textarea.wait_for(state="visible", timeout=30_000)
+    textarea.scroll_into_view_if_needed()
+    textarea.click()
+
+    with page.expect_file_chooser() as file_chooser_info:
+        page.get_by_role("button", name=re.compile("add files", re.IGNORECASE)).click()
+    file_chooser = file_chooser_info.value
+    file_chooser.set_files([str(image.path) for image in images])
+
+    deadline = time.time() + timeout_seconds
+    last_value = ""
+    while time.time() < deadline:
+        last_value = textarea.input_value()
+        urls = ATTACHMENT_URL_RE.findall(last_value)
+        if len(urls) >= len(images):
+            return urls[: len(images)]
+        page.wait_for_timeout(1_000)
+
+    raise RuntimeError(
+        "Timed out waiting for GitHub attachment URLs to appear in the comment form. "
+        f"Last textarea value: {last_value!r}"
+    )
+
+
+def write_outputs(
+    output_dir: Path,
+    target_url: str,
+    mockup_url: str,
+    images: Sequence[CapturedImage],
+    asset_urls: Sequence[str],
+) -> None:
+    """Write the manifest and Markdown snippet."""
+    snippet_path = output_dir / "snippet.md"
+    manifest_path = output_dir / "manifest.json"
+    snippet = render_snippet(images, asset_urls)
+    manifest = {
+        "target_url": target_url,
+        "mockup_url": mockup_url,
+        "images": [
+            {
+                "slug": image.slug,
+                "selector": image.selector,
+                "png_path": str(image.path),
+                "uploaded_url": asset_url,
+            }
+            for image, asset_url in zip(images, asset_urls)
+        ],
+    }
+    snippet_path.write_text(snippet, encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
+def run_browser_flow(
+    args: argparse.Namespace,
+    selectors: Sequence[SelectorSpec],
+    output_dir: Path,
+) -> tuple[list[CapturedImage], list[str]]:
+    """Run the Playwright flow and return captured images and uploaded URLs."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise RuntimeError("Playwright is required to run this helper. Install it in your active Python environment.") from exc
+
+    browser_path = Path(args.browser_path).expanduser().resolve()
+    launch_kwargs: dict[str, Any] = {"headless": args.headless}
+    if browser_path.exists():
+        launch_kwargs["executable_path"] = str(browser_path)
+
+    auth_state = Path(args.auth_state).expanduser().resolve()
+    if not auth_state.exists():
+        raise FileNotFoundError(f"Missing Playwright auth state: {auth_state}")
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(**launch_kwargs)
+        context = browser.new_context(storage_state=str(auth_state), viewport={"width": 1600, "height": 1200})
+        page = context.new_page()
+        images = capture_screenshots(page, args.mockup_url, selectors, output_dir)
+        asset_urls = upload_images(page, build_target_url(args.repo, args.issue, args.pr), images, args.timeout_seconds)
+        context.close()
+        browser.close()
+    return images, asset_urls
+
+
+def main() -> int:
+    """Run the CLI."""
+    args = parse_args()
+    output_dir = Path(args.output).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    selector_file = Path(args.selectors).expanduser().resolve()
+    if not selector_file.exists():
+        print(f"Selector file does not exist: {selector_file}", file=sys.stderr)
+        return 2
+
+    try:
+        selectors = load_selectors(selector_file)
+        target_url = build_target_url(args.repo, args.issue, args.pr)
+        images, asset_urls = run_browser_flow(args, selectors, output_dir)
+        write_outputs(output_dir, target_url, args.mockup_url, images, asset_urls)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Uploaded {len(asset_urls)} image(s) to {target_url}")
+    print(f"Saved snippet to {output_dir / 'snippet.md'}")
+    print(f"Saved manifest to {output_dir / 'manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ai-skills/feature-design/skill.yaml
+++ b/ai-skills/feature-design/skill.yaml
@@ -1,0 +1,7 @@
+name: feature-design
+description: "Use when designing a feature from a request, draft issue, references, PRs, screenshots, or code context, and the goal is an implementation-ready GitHub issue."
+codex:
+  interface:
+    display_name: Feature Design
+    short_description: Design features and write implementation-ready GitHub issues
+    default_prompt: Use $feature-design to turn a request into an implementation-ready GitHub issue.

--- a/docs/AI_SKILLS.md
+++ b/docs/AI_SKILLS.md
@@ -1,0 +1,98 @@
+# AI Skills
+
+This template ships a canonical `ai-skills/` source tree that renders to both Claude and Codex. The source files live in the repository once, and the deploy workflow writes the harness-specific outputs into `~/.claude/skills/` and `~/.codex/skills/`.
+
+## Why use a canonical source
+
+Using one source of truth avoids drift between platform-specific skill directories:
+- `instructions.md` is rendered into Claude's `skill.md` and Codex's `SKILL.md`
+- the same optional `references/`, `scripts/`, and `assets/` directories are synced to both targets
+- Codex-only interface metadata stays in `skill.yaml` instead of being hand-maintained in generated output
+
+## Starter skills
+
+The template ships two starter skills:
+- `feature-delivery`
+  - Guides issue-driven delivery from branch creation through tests, PR, CI, review, merge, and cleanup.
+- `feature-design`
+  - Guides turning rough requests into implementation-ready GitHub issues and includes a helper for mockup screenshot uploads.
+
+These replace the older placeholder scaffold pattern and are intended to be copied, extended, or used as reference implementations for new project-specific skills.
+
+## Canonical structure
+
+Each skill lives under `ai-skills/<skill-name>/`:
+
+```text
+ai-skills/
+  <skill-name>/
+    skill.yaml
+    instructions.md
+    references/   # optional
+    scripts/      # optional
+    assets/       # optional
+```
+
+`skill.yaml` contains the shared manifest plus Codex UI metadata:
+
+```yaml
+name: example-skill
+description: One-line description used by both Claude and Codex.
+codex:
+  interface:
+    display_name: Example Skill
+    short_description: Short label shown in Codex UI
+    default_prompt: Use $example-skill to do the thing.
+```
+
+## Deploy locally
+
+Use the wrapper script:
+
+```bash
+./scripts/deploy_ai_skills.sh
+```
+
+Or run the playbook directly:
+
+```bash
+ansible-playbook infra/ai-skills/deploy_ai_skills.yml
+```
+
+The deploy workflow:
+- discovers all `skill.yaml` manifests under `ai-skills/`
+- renders Claude `skill.md` files into `~/.claude/skills/<name>/`
+- renders Codex `SKILL.md` and `agents/openai.yaml` files into `~/.codex/skills/<name>/`
+- syncs optional `references/`, `scripts/`, and `assets/` directories to both targets
+
+## Add a new skill
+
+1. Create `ai-skills/<name>/skill.yaml`.
+2. Write the skill body in `ai-skills/<name>/instructions.md`.
+3. Add optional `references/`, `scripts/`, or `assets/` directories when the skill needs them.
+4. Run `./scripts/deploy_ai_skills.sh`.
+5. Confirm the rendered files appear under both `~/.claude/skills/<name>/` and `~/.codex/skills/<name>/`.
+
+Use `feature-delivery` and `feature-design` as the worked examples for naming, manifest structure, and how much guidance to include.
+
+## Rendering differences
+
+Claude and Codex share the same Markdown body, but the generated output differs slightly:
+- Claude gets `skill.md`
+- Codex gets `SKILL.md`
+- Codex also gets `agents/openai.yaml` built from `skill.yaml`'s `codex.interface` block
+
+The source directory remains canonical. Generated output should not be edited by hand.
+
+## Troubleshooting
+
+If a skill does not appear after deploy:
+- verify `ansible-playbook` is installed and on your path
+- confirm the skill has both `skill.yaml` and `instructions.md`
+- make sure `skill.yaml` parses as valid YAML
+- rerun `./scripts/deploy_ai_skills.sh` and inspect any Ansible errors
+
+If Claude or Codex rejects a rendered skill:
+- inspect the generated frontmatter under `~/.claude/skills/` or `~/.codex/skills/`
+- check for malformed YAML or unsupported quoting in `skill.yaml`
+- verify that `instructions.md` does not contain accidental template markers or broken fenced code blocks

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,6 +35,11 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Verification steps
 - Troubleshooting
 
+**[AI_SKILLS.md](AI_SKILLS.md)**
+- Canonical AI skills source tree
+- Dual deployment to Claude and Codex
+- Starter skills and local deploy workflow
+
 ---
 
 ## Architecture
@@ -56,6 +61,11 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Core workflow and key components
 - Development commands and setup
 - Common development tasks
+
+**[AI_SKILLS.md](AI_SKILLS.md)**
+- Canonical `ai-skills/` structure and starter skills
+- Local deploy workflow for Claude and Codex skill output
+- Troubleshooting rendered skill output
 
 **[CI.md](CI.md)**
 - Continuous Integration (CI) pipeline documentation
@@ -89,6 +99,7 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 |----------|---------|----------|
 | [README.md](../README.md) | Getting started, installation, usage | All users |
 | [SETUP.md](SETUP.md) | Environment configuration | All users |
+| [AI_SKILLS.md](AI_SKILLS.md) | AI skill source, deploy, and starter-skill guide | Developers |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Technical architecture and design | Developers |
 | [CI.md](CI.md) | CI/CD pipeline and development workflow | Developers |
 | [CLAUDE.md](../CLAUDE.md) | AI assistant guidance | Claude Code |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -100,6 +100,25 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+### Deploy AI Skills
+
+The template ships canonical AI skill sources under `ai-skills/` and a deploy flow that renders them to both Claude and Codex:
+
+```bash
+./scripts/deploy_ai_skills.sh
+```
+
+Requirements:
+- `ansible-playbook` installed locally
+- write access to `~/.claude/skills/` and `~/.codex/skills/`
+
+The deploy script renders:
+- Claude skills to `~/.claude/skills/<name>/skill.md`
+- Codex skills to `~/.codex/skills/<name>/SKILL.md`
+- Codex interface metadata to `~/.codex/skills/<name>/agents/openai.yaml`
+
+See [AI_SKILLS.md](AI_SKILLS.md) for the canonical source layout, starter skills, and troubleshooting guidance.
+
 ### IDE Setup
 
 #### VS Code

--- a/infra/ai-skills/deploy_ai_skills.yml
+++ b/infra/ai-skills/deploy_ai_skills.yml
@@ -1,0 +1,128 @@
+---
+- name: Deploy canonical AI skills to Codex and Claude
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    repo_root: "{{ playbook_dir | dirname | dirname }}"
+    canonical_skills_dir: "{{ repo_root }}/ai-skills"
+    codex_skills_dir: "{{ lookup('ansible.builtin.env', 'HOME') }}/.codex/skills"
+    claude_skills_dir: "{{ lookup('ansible.builtin.env', 'HOME') }}/.claude/skills"
+    template_dir: "{{ repo_root }}/infra/ai-skills/templates"
+    resource_dirs:
+      - references
+      - scripts
+      - assets
+
+  tasks:
+    - name: Discover canonical skill manifests
+      ansible.builtin.find:
+        paths: "{{ canonical_skills_dir }}"
+        patterns: skill.yaml
+        file_type: file
+        recurse: true
+      register: discovered_skill_manifests
+
+    - name: Collect canonical skill manifest paths
+      ansible.builtin.set_fact:
+        skill_manifest_paths: "{{ discovered_skill_manifests.files | map(attribute='path') | sort }}"
+
+    - name: Fail when no canonical skills are defined
+      ansible.builtin.assert:
+        that:
+          - skill_manifest_paths | length > 0
+        fail_msg: "No canonical skills found under {{ canonical_skills_dir }}."
+
+    - name: Load canonical skill manifests
+      ansible.builtin.set_fact:
+        canonical_skills: >-
+          {{
+            (canonical_skills | default([]))
+            + [ {
+                  'source_dir': item | dirname,
+                  'manifest': (lookup('ansible.builtin.file', item) | from_yaml)
+                } ]
+          }}
+      loop: "{{ skill_manifest_paths }}"
+      loop_control:
+        label: "{{ item | basename }}"
+
+    - name: Ensure target skill roots exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ codex_skills_dir }}"
+        - "{{ claude_skills_dir }}"
+
+    - name: Record available canonical resource directories
+      ansible.builtin.stat:
+        path: "{{ item.0.source_dir }}/{{ item.1 }}"
+      loop: "{{ canonical_skills | product(resource_dirs) | list }}"
+      register: canonical_resource_dirs
+      loop_control:
+        label: "{{ item.0.manifest.name }}/{{ item.1 }}"
+
+    - name: Ensure Codex skill directories exist
+      ansible.builtin.file:
+        path: "{{ codex_skills_dir }}/{{ item.manifest.name }}/agents"
+        state: directory
+        mode: "0755"
+      loop: "{{ canonical_skills }}"
+      loop_control:
+        label: "{{ item.manifest.name }}"
+
+    - name: Render Codex SKILL.md files
+      ansible.builtin.template:
+        src: "{{ template_dir }}/codex-skill.md.j2"
+        dest: "{{ codex_skills_dir }}/{{ item.manifest.name }}/SKILL.md"
+        mode: "0644"
+      loop: "{{ canonical_skills }}"
+      loop_control:
+        label: "{{ item.manifest.name }}"
+
+    - name: Render Codex openai.yaml files
+      ansible.builtin.template:
+        src: "{{ template_dir }}/codex-openai.yaml.j2"
+        dest: "{{ codex_skills_dir }}/{{ item.manifest.name }}/agents/openai.yaml"
+        mode: "0644"
+      loop: "{{ canonical_skills }}"
+      loop_control:
+        label: "{{ item.manifest.name }}"
+
+    - name: Sync Codex resource directories
+      ansible.builtin.copy:
+        src: "{{ item.item.0.source_dir }}/{{ item.item.1 }}/"
+        dest: "{{ codex_skills_dir }}/{{ item.item.0.manifest.name }}/{{ item.item.1 }}/"
+      loop: "{{ canonical_resource_dirs.results }}"
+      when: item.stat.exists and item.stat.isdir
+      loop_control:
+        label: "{{ item.item.0.manifest.name }}/{{ item.item.1 }}"
+
+    - name: Ensure Claude skill directories exist
+      ansible.builtin.file:
+        path: "{{ claude_skills_dir }}/{{ item.manifest.name }}"
+        state: directory
+        mode: "0755"
+      loop: "{{ canonical_skills }}"
+      loop_control:
+        label: "{{ item.manifest.name }}"
+
+    - name: Render Claude skill.md files
+      ansible.builtin.template:
+        src: "{{ template_dir }}/claude-skill.md.j2"
+        dest: "{{ claude_skills_dir }}/{{ item.manifest.name }}/skill.md"
+        mode: "0644"
+      loop: "{{ canonical_skills }}"
+      loop_control:
+        label: "{{ item.manifest.name }}"
+
+    - name: Sync Claude resource directories
+      ansible.builtin.copy:
+        src: "{{ item.item.0.source_dir }}/{{ item.item.1 }}/"
+        dest: "{{ claude_skills_dir }}/{{ item.item.0.manifest.name }}/{{ item.item.1 }}/"
+      loop: "{{ canonical_resource_dirs.results }}"
+      when: item.stat.exists and item.stat.isdir
+      loop_control:
+        label: "{{ item.item.0.manifest.name }}/{{ item.item.1 }}"

--- a/infra/ai-skills/templates/claude-skill.md.j2
+++ b/infra/ai-skills/templates/claude-skill.md.j2
@@ -1,0 +1,6 @@
+---
+name: {{ item.manifest.name | to_json }}
+description: {{ item.manifest.description | to_json }}
+---
+
+{{ lookup('ansible.builtin.file', item.source_dir ~ '/instructions.md') | trim }}

--- a/infra/ai-skills/templates/codex-openai.yaml.j2
+++ b/infra/ai-skills/templates/codex-openai.yaml.j2
@@ -1,0 +1,4 @@
+interface:
+  display_name: {{ item.manifest.codex.interface.display_name | to_json }}
+  short_description: {{ item.manifest.codex.interface.short_description | to_json }}
+  default_prompt: {{ item.manifest.codex.interface.default_prompt | to_json }}

--- a/infra/ai-skills/templates/codex-skill.md.j2
+++ b/infra/ai-skills/templates/codex-skill.md.j2
@@ -1,0 +1,6 @@
+---
+name: {{ item.manifest.name | to_json }}
+description: {{ item.manifest.description | to_json }}
+---
+
+{{ lookup('ansible.builtin.file', item.source_dir ~ '/instructions.md') | trim }}

--- a/scripts/deploy_ai_skills.sh
+++ b/scripts/deploy_ai_skills.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+playbook="$repo_root/infra/ai-skills/deploy_ai_skills.yml"
+
+if ! command -v ansible-playbook >/dev/null 2>&1; then
+  echo "ansible-playbook is required to deploy AI skills." >&2
+  exit 1
+fi
+
+exec ansible-playbook "$playbook" "$@"

--- a/tests/test_github_mockup_issue_assets.py
+++ b/tests/test_github_mockup_issue_assets.py
@@ -1,0 +1,75 @@
+"""Tests for the GitHub mockup asset helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "ai-skills"
+    / "feature-design"
+    / "scripts"
+    / "github_mockup_issue_assets.py"
+)
+MODULE_SPEC = importlib.util.spec_from_file_location("github_mockup_issue_assets", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+github_mockup_issue_assets = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = github_mockup_issue_assets
+MODULE_SPEC.loader.exec_module(github_mockup_issue_assets)
+
+
+def test_build_target_url_for_issue() -> None:
+    """Issue URLs should use the issues path."""
+    assert (
+        github_mockup_issue_assets.build_target_url("openai/example", 42, None)
+        == "https://github.com/openai/example/issues/42"
+    )
+
+
+def test_build_target_url_for_pr() -> None:
+    """PR URLs should use the pull path."""
+    assert (
+        github_mockup_issue_assets.build_target_url("openai/example", None, 7)
+        == "https://github.com/openai/example/pull/7"
+    )
+
+
+def test_parse_selector_line_supports_explicit_slug() -> None:
+    """Selector files can provide a stable output slug explicitly."""
+    spec = github_mockup_issue_assets.parse_selector_line("hero-card=.hero-card", 1)
+    assert spec is not None
+    assert spec.slug == "hero-card"
+    assert spec.selector == ".hero-card"
+
+
+def test_parse_selector_line_ignores_comments() -> None:
+    """Comment lines should be ignored."""
+    assert github_mockup_issue_assets.parse_selector_line("# note", 1) is None
+
+
+def test_parse_selector_line_derives_slug_when_missing() -> None:
+    """Selectors without a slug should still get a stable filename."""
+    spec = github_mockup_issue_assets.parse_selector_line('[data-view="main"] .hero-card', 3)
+    assert spec is not None
+    assert spec.slug == "03-data-view-main-hero"
+    assert spec.selector == '[data-view="main"] .hero-card'
+
+
+def test_render_snippet_includes_selector_metadata() -> None:
+    """The generated snippet should map each image to its selector."""
+    image = github_mockup_issue_assets.CapturedImage(
+        slug="hero-card",
+        selector=".hero-card",
+        path=Path("/tmp/hero-card.png"),
+    )
+    rendered = github_mockup_issue_assets.render_snippet(
+        [image],
+        ["https://github.com/user-attachments/assets/12345678-1234-1234-1234-1234567890ab"],
+    )
+    assert "## Visual Guide" in rendered
+    assert "### `hero-card`" in rendered
+    assert "Selector: `.hero-card`" in rendered


### PR DESCRIPTION
## Summary

This PR implements issue #11 by adding two production-ready starter skills under `ai-skills/`:
- `feature-delivery`
- `feature-design`

Because `#11` depends on the canonical dual-deploy skill workflow from `#9`, this PR also brings in the minimal scaffolding required to make the new skills usable:
- `infra/ai-skills/deploy_ai_skills.yml`
- `infra/ai-skills/templates/`
- `scripts/deploy_ai_skills.sh`
- `docs/AI_SKILLS.md`

It also updates the setup and template usage docs so the starter skills and deploy flow are discoverable.

Closes #11.

## Validation

- `source venv/bin/activate && pytest -c /dev/null --rootdir=. tests/test_github_mockup_issue_assets.py`
- `source venv/bin/activate && ansible-playbook infra/ai-skills/deploy_ai_skills.yml --check`
- `PATH="$(pwd)/venv/bin:$PATH" ./scripts/deploy_ai_skills.sh`
- `source venv/bin/activate && python -m py_compile ai-skills/feature-design/scripts/github_mockup_issue_assets.py tests/test_github_mockup_issue_assets.py`
- `bash -n scripts/deploy_ai_skills.sh`

## Notes

`pre-commit run --all-files` is currently blocked in the raw template repository because unresolved template placeholders make `.pre-commit-config.yaml` and `pyproject.toml` non-parseable before instantiation. That is a pre-existing template limitation, not introduced by this PR.
