### PR TITLE
docs(skills): require worktrees in feature delivery

### DIFF
--- a/ai-skills/feature-delivery/instructions.md
+++ b/ai-skills/feature-delivery/instructions.md
@@ -17,20 +17,20 @@ Workflow:
    - use `gh issue view <number>` to read the issue body
    - use `gh issue view <number> --comments` when comments or clarifications may affect scope
    - do not rely only on branch names, PR titles, or secondhand summaries when the issue itself is available
-3. Create a dedicated branch using repo naming rules:
+3. Create a dedicated Git worktree from fresh `main`. Do not implement feature work directly in the primary repo checkout.
+4. Create a dedicated branch in that worktree using repo naming rules:
    - `feature/...` for features
    - `fix/...` for bug fixes
    - `docs/...` for docs-only work
    - include the GitHub issue number near the front when relevant, for example `feature/123-api-cleanup`
-   - a dedicated worktree is optional when it helps keep the primary checkout clean
-4. Implement the issue scope in that branch or worktree.
-5. Document architecture usage and explain how the change works.
-6. Update docs and Mermaid/context docs when schema, API surface, control flow, or data flow changes.
-7. Run targeted tests, then `pre-commit`, and fix failures before commit.
-8. Commit with a conventional message, push the branch, and open a PR that closes the issue.
-9. Wait for CI and fix failures until green.
-10. Once CI is green, request an external review by adding `@codex review` or the repository's equivalent review trigger on the pull request.
-11. While waiting for the review to arrive, review your own PR and leave a self-review comment that covers the main change, primary risks, and any test or verification gaps you still see.
+5. Implement the issue scope in that worktree.
+6. Document architecture usage and explain how the change works.
+7. Update docs and Mermaid/context docs when schema, API surface, control flow, or data flow changes.
+8. Run targeted tests, then `pre-commit`, and fix failures before commit.
+9. Commit with a conventional message, push the branch, and open a PR that closes the issue.
+10. Wait for CI and fix failures until green.
+11. Once CI is green, request an external review by adding `@codex review` or the repository's equivalent review trigger on the pull request.
+12. While waiting for the review to arrive, review your own PR and leave a self-review comment that covers the main change, primary risks, and any test or verification gaps you still see.
    - scale self-review depth to implementation risk
    - for high-risk changes such as background automation, queue processing, task lifecycle, API or CLI concurrency, locks, retries, sync high-water marks, stale-run cleanup, or cancellation paths, do not stop at happy-path behavior and basic observability
    - in high-risk self-review, explicitly challenge failure modes such as:
@@ -43,8 +43,8 @@ Workflow:
      - queue row state transitions and terminal-update preconditions
      - lock acquisition and release behavior, including pool starvation and request shutdown
    - if repeated risks fall into the same category, pause and audit the whole category before asking for another review
-12. Wait up to five minutes for the external review to arrive. If no review is present after five minutes, skip the external review requirement and continue the process.
-13. Read the review carefully and participate in the feedback loop:
+13. Wait up to five minutes for the external review to arrive. If no review is present after five minutes, skip the external review requirement and continue the process.
+14. Read the review carefully and participate in the feedback loop:
    - inline review comments are not visible in `gh pr view --json reviews,comments`; that command is not a sufficient review audit
    - always audit review threads with GraphQL before deciding there are no actionable findings:
      ```bash
@@ -78,7 +78,7 @@ Workflow:
      ```
    - treat any review-thread comment with an actionable finding as requiring an inline reply, even if the top-level review body is generic
    - as soon as a review lands, audit the review threads and reply in-thread before starting the next round of fixes
-   - do not treat review comments as a private TODO list while leaving the GitHub threads unanswered
+   - do not treat review comments as a private TODO list while leaving the GitHub threads unanswered; acknowledge the finding in-thread first, even if the reply is only that you are investigating or plan to address it in the next commit
    - reply to each review comment directly as a reply to that comment thread, not as a new top-level PR comment
    - do this for every review round, including follow-up reviews after additional commits
    - after each new review lands, explicitly audit the PR review threads and identify any new unresolved findings before deciding the PR is ready
@@ -99,10 +99,10 @@ Workflow:
    - only defer review feedback to a follow-up when there is a good reason not to expand the current PR, such as materially increased scope, materially increased complexity, a riskier change, or a case that needs more careful design work
    - if the feedback should be deferred, create a follow-up issue and explain why it is not being fixed in the current PR
    - if the feedback is not applicable, document why in the PR so the resolution is explicit
-14. After responding to review and your self-review findings, leave the required decision comment describing what was fixed now, deferred, or not done.
-15. If a follow-up issue is needed, create it with a title starting `[followup]`.
-16. Merge the PR.
-17. Return to `main`, pull fresh `origin/main`, clean up the feature branch or worktree, and update any session notes if the repository uses them.
+15. After responding to review and your self-review findings, leave the required decision comment describing what was fixed now, deferred, or not done.
+16. If a follow-up issue is needed, create it with a title starting `[followup]`.
+17. Merge the PR.
+18. Return to the primary checkout, pull fresh `origin/main`, clean up the feature branch, remove the merged worktree, and update any session notes if the repository uses them.
 
 Guardrails:
 - PR by default; direct push only when the user explicitly asks for it.
@@ -113,3 +113,5 @@ Guardrails:
 - Once review lands, reply in-thread before diving into more implementation work.
 - Before merge, run the GraphQL review-thread audit above and verify that every review finding has an inline reply and an explicit disposition, especially after follow-up commits and re-reviews.
 - Before merge, do not rely on top-level PR comments or `gh pr view --json reviews,comments` as proof that review feedback was handled.
+- Keep the primary repo checkout as the clean control checkout; do feature coding inside the dedicated worktree only.
+- Remove merged worktrees promptly so stale branches and stale directories do not accumulate.

--- a/ai-skills/feature-delivery/skill.yaml
+++ b/ai-skills/feature-delivery/skill.yaml
@@ -1,7 +1,7 @@
 name: feature-delivery
-description: Use when delivering GitHub issues end to end through branch, tests, PR, CI, review, merge, and cleanup.
+description: Use when delivering GitHub issues end to end through dedicated git worktree, tests, PR, CI, review, merge, and cleanup.
 codex:
   interface:
     display_name: Feature Delivery
-    short_description: Implement GitHub issues end to end
+    short_description: Implement GitHub issues end to end in a worktree
     default_prompt: Use $feature-delivery to deliver a GitHub issue end to end.


### PR DESCRIPTION
## Summary
- update the canonical `feature-delivery` skill to require a dedicated git worktree
- clarify that feature work should not happen in the primary checkout
- add cleanup guidance to remove merged worktrees promptly

## Why
This brings the generic template skill in line with the desired delivery workflow so future issue work follows the worktree-first pattern by default.

## Validation
- reviewed rendered skill manifest and instructions in-repo
- confirmed the updated instructions explicitly require a dedicated worktree and cleanup at the end