### PR TITLE
feat: add release deployment skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,523 @@
+name: Release Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref or commit to deploy
+        required: false
+        default: "{{MAIN_BRANCH}}"
+        type: string
+      release_tag:
+        description: Release tag to create or verify
+        required: true
+        type: string
+      target:
+        description: Deployment target
+        required: true
+        default: hetzner
+        type: choice
+        options:
+          - hetzner
+          - home_worker
+      smoke_level:
+        description: Post-deploy smoke-test depth
+        required: true
+        default: basic
+        type: choice
+        options:
+          - basic
+          - extended
+  release:
+    types: [published]
+
+concurrency:
+  group: release-global
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-release:
+    name: Deploy Release
+    if: >-
+      github.event_name != 'release' ||
+      !contains(github.event.release.body || '', '<!-- {{PROJECT_NAME}}-release-origin: workflow_dispatch -->')
+    runs-on:
+      - self-hosted
+      - linux
+    env:
+      WORKFLOW_DISPATCH_MARKER: "<!-- {{PROJECT_NAME}}-release-origin: workflow_dispatch -->"
+      DEPLOYMENT_STATUS_START: "<!-- deployment-status:start -->"
+      DEPLOYMENT_STATUS_END: "<!-- deployment-status:end -->"
+    steps:
+      - name: Repair runner workspace before checkout
+        env:
+          WORKSPACE_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+
+          allowed_pattern='(^|/)_work/[^/]+/[^/]+$'
+          if [[ ! "${WORKSPACE_ROOT}" =~ ${allowed_pattern} ]]; then
+            echo "::error::Refusing to clean unexpected workspace path: ${WORKSPACE_ROOT}"
+            exit 1
+          fi
+
+          repo_dir="${WORKSPACE_ROOT}/repo"
+          mkdir -p "${repo_dir}"
+          find "${repo_dir}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: repo
+
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE/repo"
+
+      - name: Authorize release actor
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const actor = context.actor;
+            const owner = context.repo.owner;
+            const organizationLogin = context.payload.organization?.login ?? "";
+
+            if (!organizationLogin) {
+              if (actor !== owner) {
+                core.setFailed(
+                  `Only repository owner ${owner} may run the release workflow for user-owned repositories.`,
+                );
+              }
+              return;
+            }
+
+            const response = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: actor,
+            });
+
+            if (response.data.permission !== "admin") {
+              core.setFailed(
+                `Actor ${actor} must have admin repository permission to run the release workflow for organization-owned repositories.`,
+              );
+            }
+
+      - name: Resolve release context
+        id: context
+        working-directory: repo
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_TARGET: ${{ github.event.inputs.target }}
+          INPUT_SMOKE_LEVEL: ${{ github.event.inputs.smoke_level }}
+        run: python3 scripts/github/resolve_release_context.py
+
+      - name: Create or verify release tag
+        working-directory: repo
+        env:
+          RELEASE_TAG: ${{ steps.context.outputs.release_tag }}
+          DEPLOY_REF: ${{ steps.context.outputs.deploy_ref }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags origin
+
+          expected_commit="$(git rev-parse "${DEPLOY_REF}")"
+          if git rev-parse --verify "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            tagged_commit="$(git rev-list -n 1 "${RELEASE_TAG}")"
+            if [[ "${tagged_commit}" != "${expected_commit}" ]]; then
+              echo "::error::Tag ${RELEASE_TAG} already exists at ${tagged_commit}, expected ${expected_commit}."
+              exit 1
+            fi
+            echo "Tag ${RELEASE_TAG} already points to ${expected_commit}."
+          else
+            git tag "${RELEASE_TAG}" "${expected_commit}"
+            git push origin "refs/tags/${RELEASE_TAG}"
+            echo "Created and pushed tag ${RELEASE_TAG} -> ${expected_commit}."
+          fi
+
+      - name: Upsert GitHub release with in-progress deployment status
+        uses: actions/github-script@v8
+        env:
+          RELEASE_TAG: ${{ steps.context.outputs.release_tag }}
+          DEPLOY_REF: ${{ steps.context.outputs.deploy_ref }}
+          RELEASE_TRIGGER: ${{ steps.context.outputs.trigger }}
+          DEPLOY_TARGET: ${{ steps.context.outputs.target }}
+          SMOKE_LEVEL: ${{ steps.context.outputs.smoke_level }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_DISPATCH_MARKER: ${{ env.WORKFLOW_DISPATCH_MARKER }}
+          DEPLOYMENT_STATUS_START: ${{ env.DEPLOYMENT_STATUS_START }}
+          DEPLOYMENT_STATUS_END: ${{ env.DEPLOYMENT_STATUS_END }}
+        with:
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            const deployRef = process.env.DEPLOY_REF;
+            const trigger = process.env.RELEASE_TRIGGER;
+            const target = process.env.DEPLOY_TARGET;
+            const smokeLevel = process.env.SMOKE_LEVEL;
+            const runUrl = process.env.RUN_URL;
+            const startMarker = process.env.DEPLOYMENT_STATUS_START;
+            const endMarker = process.env.DEPLOYMENT_STATUS_END;
+            const workflowDispatchMarker = process.env.WORKFLOW_DISPATCH_MARKER;
+
+            function stripStatusSection(body) {
+              if (!body) {
+                return "";
+              }
+              const pattern = new RegExp(
+                `${startMarker}[\\s\\S]*?${endMarker}\\n?`,
+                "g",
+              );
+              return body.replace(pattern, "").trim();
+            }
+
+            function ensureOriginMarker(body) {
+              if (trigger !== "workflow_dispatch") {
+                return body;
+              }
+              return body.includes(workflowDispatchMarker)
+                ? body
+                : [body, workflowDispatchMarker].filter(Boolean).join("\n\n");
+            }
+
+            const statusSection = [
+              startMarker,
+              "## Deployment Status",
+              "",
+              "- State: in_progress",
+              `- Target: ${target}`,
+              `- Smoke level: ${smokeLevel}`,
+              `- Deploy ref: \`${deployRef}\``,
+              `- Workflow run: ${runUrl}`,
+              endMarker,
+            ].join("\n");
+
+            let release;
+            try {
+              const response = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              release = response.data;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const baseBody = ensureOriginMarker(stripStatusSection(release?.body ?? ""));
+            const finalBody = [baseBody, statusSection].filter(Boolean).join("\n\n");
+
+            if (release) {
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.id,
+                tag_name: tag,
+                target_commitish: deployRef,
+                name: release.name || tag,
+                body: finalBody,
+              });
+            } else {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                target_commitish: deployRef,
+                name: tag,
+                body: finalBody,
+              });
+            }
+
+      - name: Pre-flight required secrets check
+        working-directory: repo
+        env:
+          DEPLOY_TARGET: ${{ steps.context.outputs.target }}
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          HETZNER_INVENTORY: ${{ secrets.HETZNER_INVENTORY }}
+          HETZNER_SECRETS_YAML: ${{ secrets.HETZNER_SECRETS_YAML }}
+          HETZNER_BASE_URL: ${{ secrets.HETZNER_BASE_URL }}
+          HOME_WORKER_INVENTORY: ${{ secrets.HOME_WORKER_INVENTORY }}
+          HOME_WORKER_SECRETS_YAML: ${{ secrets.HOME_WORKER_SECRETS_YAML }}
+          HOME_WORKER_BASE_URL: ${{ secrets.HOME_WORKER_BASE_URL }}
+        run: |
+          set -euo pipefail
+
+          required_common=(
+            DEPLOY_SSH_PRIVATE_KEY
+            DEPLOY_KNOWN_HOSTS
+          )
+
+          case "${DEPLOY_TARGET}" in
+            hetzner)
+              required_target=(
+                HETZNER_INVENTORY
+                HETZNER_SECRETS_YAML
+                HETZNER_BASE_URL
+              )
+              ;;
+            home_worker)
+              required_target=(
+                HOME_WORKER_INVENTORY
+                HOME_WORKER_SECRETS_YAML
+                HOME_WORKER_BASE_URL
+              )
+              ;;
+            *)
+              echo "::error::Unsupported deployment target: ${DEPLOY_TARGET}"
+              exit 1
+              ;;
+          esac
+
+          missing=()
+          for var_name in "${required_common[@]}" "${required_target[@]}"; do
+            if [[ -z "${!var_name:-}" ]]; then
+              missing+=("${var_name}")
+            fi
+          done
+
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            printf '::error::Missing required GitHub secrets for target %s: %s\n' \
+              "${DEPLOY_TARGET}" "${missing[*]}"
+            exit 1
+          fi
+
+      - name: Ensure ansible-core is available
+        run: |
+          set -euo pipefail
+
+          if command -v ansible >/dev/null 2>&1 && command -v ansible-playbook >/dev/null 2>&1; then
+            ansible --version
+            exit 0
+          fi
+
+          if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+            if sudo apt-get update && sudo apt-get install -y ansible-core; then
+              ansible --version
+              exit 0
+            fi
+          fi
+
+          python3 -m pip install --user ansible-core
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Configure SSH material
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$HOME/.ssh"
+          chmod 700 "$HOME/.ssh"
+          printf '%s\n' "${DEPLOY_SSH_PRIVATE_KEY}" > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "${DEPLOY_KNOWN_HOSTS}" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+
+      - name: Materialize inventory and secrets
+        id: materialize
+        working-directory: repo
+        env:
+          DEPLOY_TARGET: ${{ steps.context.outputs.target }}
+          HETZNER_INVENTORY: ${{ secrets.HETZNER_INVENTORY }}
+          HETZNER_SECRETS_YAML: ${{ secrets.HETZNER_SECRETS_YAML }}
+          HETZNER_BASE_URL: ${{ secrets.HETZNER_BASE_URL }}
+          HOME_WORKER_INVENTORY: ${{ secrets.HOME_WORKER_INVENTORY }}
+          HOME_WORKER_SECRETS_YAML: ${{ secrets.HOME_WORKER_SECRETS_YAML }}
+          HOME_WORKER_BASE_URL: ${{ secrets.HOME_WORKER_BASE_URL }}
+        run: |
+          set -euo pipefail
+
+          case "${DEPLOY_TARGET}" in
+            hetzner)
+              inventory_path="infra/hetzner/inventory.local.ini"
+              secrets_path="infra/hetzner/secrets.yml"
+              inventory_contents="${HETZNER_INVENTORY}"
+              secrets_contents="${HETZNER_SECRETS_YAML}"
+              base_url="${HETZNER_BASE_URL}"
+              ;;
+            home_worker)
+              inventory_path="infra/home-worker/inventory.local.ini"
+              secrets_path="infra/home-worker/secrets.yml"
+              inventory_contents="${HOME_WORKER_INVENTORY}"
+              secrets_contents="${HOME_WORKER_SECRETS_YAML}"
+              base_url="${HOME_WORKER_BASE_URL}"
+              ;;
+            *)
+              echo "::error::Unsupported deployment target: ${DEPLOY_TARGET}"
+              exit 1
+              ;;
+          esac
+
+          printf '%s\n' "${inventory_contents}" > "${inventory_path}"
+          printf '%s\n' "${secrets_contents}" > "${secrets_path}"
+
+          echo "inventory_path=${inventory_path}" >> "$GITHUB_OUTPUT"
+          echo "secrets_path=${secrets_path}" >> "$GITHUB_OUTPUT"
+          echo "base_url=${base_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate materialized secrets YAML
+        working-directory: repo
+        env:
+          SECRETS_PATH: ${{ steps.materialize.outputs.secrets_path }}
+        run: |
+          set -euo pipefail
+          ansible localhost -i 'localhost,' -c local \
+            -m debug \
+            -a 'msg=validated secrets file' \
+            -e "@${SECRETS_PATH}"
+
+      - name: Deploy target
+        working-directory: repo
+        env:
+          DEPLOY_TARGET: ${{ steps.context.outputs.target }}
+          DEPLOY_REF: ${{ steps.context.outputs.deploy_ref }}
+          INVENTORY_PATH: ${{ steps.materialize.outputs.inventory_path }}
+          SECRETS_PATH: ${{ steps.materialize.outputs.secrets_path }}
+        run: |
+          set -euo pipefail
+          ./scripts/redeploy.sh \
+            --target "${DEPLOY_TARGET}" \
+            --deploy-ref "${DEPLOY_REF}" \
+            --inventory "${INVENTORY_PATH}" \
+            --secrets-file "${SECRETS_PATH}"
+
+      - name: Smoke check deployment
+        working-directory: repo
+        env:
+          BASE_URL: ${{ steps.materialize.outputs.base_url }}
+          SMOKE_LEVEL: ${{ steps.context.outputs.smoke_level }}
+          EXPECTED_REF: ${{ steps.context.outputs.deploy_ref }}
+        run: |
+          set -euo pipefail
+          ./scripts/release_smoke_check.sh \
+            --base-url "${BASE_URL}" \
+            --smoke-level "${SMOKE_LEVEL}" \
+            --expected-ref "${EXPECTED_REF}"
+
+      - name: Update GitHub release status after successful deploy
+        if: success()
+        uses: actions/github-script@v8
+        env:
+          RELEASE_TAG: ${{ steps.context.outputs.release_tag }}
+          DEPLOY_TARGET: ${{ steps.context.outputs.target }}
+          SMOKE_LEVEL: ${{ steps.context.outputs.smoke_level }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DEPLOYMENT_STATUS_START: ${{ env.DEPLOYMENT_STATUS_START }}
+          DEPLOYMENT_STATUS_END: ${{ env.DEPLOYMENT_STATUS_END }}
+        with:
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            const target = process.env.DEPLOY_TARGET;
+            const smokeLevel = process.env.SMOKE_LEVEL;
+            const runUrl = process.env.RUN_URL;
+            const startMarker = process.env.DEPLOYMENT_STATUS_START;
+            const endMarker = process.env.DEPLOYMENT_STATUS_END;
+            const completedAt = new Date().toISOString();
+
+            let release;
+            try {
+              const response = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              release = response.data;
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning(`No GitHub Release found for tag ${tag}; skipping success status update.`);
+                return;
+              }
+              throw error;
+            }
+            const baseBody = (release.body ?? "").replace(
+              new RegExp(`${startMarker}[\\s\\S]*?${endMarker}\\n?`, "g"),
+              "",
+            ).trim();
+            const statusSection = [
+              startMarker,
+              "## Deployment Status",
+              "",
+              "- State: success",
+              `- Target: ${target}`,
+              `- Smoke level: ${smokeLevel}`,
+              `- Completed at: ${completedAt}`,
+              `- Workflow run: ${runUrl}`,
+              endMarker,
+            ].join("\n");
+
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              body: [baseBody, statusSection].filter(Boolean).join("\n\n"),
+            });
+
+      - name: Update GitHub release status after failed deploy
+        if: failure()
+        uses: actions/github-script@v8
+        env:
+          RELEASE_TAG: ${{ steps.context.outputs.release_tag }}
+          DEPLOY_TARGET: ${{ steps.context.outputs.target }}
+          SMOKE_LEVEL: ${{ steps.context.outputs.smoke_level }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DEPLOYMENT_STATUS_START: ${{ env.DEPLOYMENT_STATUS_START }}
+          DEPLOYMENT_STATUS_END: ${{ env.DEPLOYMENT_STATUS_END }}
+        with:
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            const target = process.env.DEPLOY_TARGET;
+            const smokeLevel = process.env.SMOKE_LEVEL;
+            const runUrl = process.env.RUN_URL;
+            const startMarker = process.env.DEPLOYMENT_STATUS_START;
+            const endMarker = process.env.DEPLOYMENT_STATUS_END;
+            const failedAt = new Date().toISOString();
+
+            let release;
+            try {
+              const response = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              release = response.data;
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning(`No GitHub Release found for tag ${tag}; skipping failure status update.`);
+                return;
+              }
+              throw error;
+            }
+            const baseBody = (release.body ?? "").replace(
+              new RegExp(`${startMarker}[\\s\\S]*?${endMarker}\\n?`, "g"),
+              "",
+            ).trim();
+            const statusSection = [
+              startMarker,
+              "## Deployment Status",
+              "",
+              "- State: failure",
+              `- Target: ${target}`,
+              `- Smoke level: ${smokeLevel}`,
+              `- Failed at: ${failedAt}`,
+              `- Workflow run: ${runUrl}`,
+              endMarker,
+            ].join("\n");
+
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              body: [baseBody, statusSection].filter(Boolean).join("\n\n"),
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ coverage.xml
 # Security scanning cache
 .pip-audit-cache/
 
+# Deployment inventories and secrets
+infra/hetzner/inventory.local.ini
+infra/hetzner/secrets.yml
+infra/home-worker/inventory.local.ini
+infra/home-worker/secrets.yml
+
 # Temporary files
 temp/
 tmp/

--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -61,6 +61,7 @@ python-project-template/
 │   ├── workflows/
 │   │   ├── ci.yml                 # Main CI pipeline
 │   │   ├── ci-image.yml           # Shared CI image build/publish workflow
+│   │   ├── release.yml            # Manual + release-event deployment workflow
 │   │   ├── claude.yml             # Claude Code automation
 │   │   └── claude-code-review.yml # AI code review
 │   └── dependabot.yml             # Dependency updates
@@ -82,6 +83,8 @@ python-project-template/
 │   ├── ARCHITECTURE.md            # Technical design
 │   ├── CI.md                      # CI/CD documentation
 │   ├── CI_RUNNER.md               # Self-hosted runner and CI image guide
+│   ├── RELEASE_WORKFLOW.md        # Release deployment workflow guide
+│   ├── DEPLOYMENT.md              # Manual deployment runbook
 │   ├── BRANCH_PROTECTION.md       # Branch protection documentation
 │   └── planning/
 │       └── TASK_MANAGEMENT.md     # Task tracking
@@ -93,12 +96,25 @@ python-project-template/
 │   │   ├── Dockerfile             # Shared Ubuntu CI image
 │   │   ├── docker-compose.ci.yml  # Local CI container shell
 │   │   └── build-and-push.sh      # Manual multi-arch CI image helper
-│   └── home-worker/
-│       └── ci_runner_setup.yml    # Self-hosted runner bootstrap skeleton
+│   ├── hetzner/
+│   │   ├── inventory.local.ini.example # Example VPS inventory
+│   │   ├── secrets.yml.example    # Example deploy vars
+│   │   └── provision_vps.yml      # VPS bootstrap skeleton
+│   ├── home-worker/
+│   │   ├── ci_runner_setup.yml    # Self-hosted runner bootstrap skeleton
+│   │   ├── inventory.local.ini.example # Example worker inventory
+│   │   ├── secrets.yml.example    # Example worker vars
+│   │   ├── deploy_target_setup.yml # Worker/bootstrap skeleton
+│   │   └── redeploy.yml           # Home-worker redeploy skeleton
+│   └── site/
+│       └── redeploy.yml           # Site deployment orchestration skeleton
 ├── scripts/
 │   ├── deploy_ai_skills.sh        # Local AI skills deploy wrapper
+│   ├── redeploy.sh                # Ansible redeploy wrapper
+│   ├── release_smoke_check.sh     # Post-deployment smoke checks
 │   └── github/
 │       ├── branch-protection-config.json  # Protection rules config
+│       ├── resolve_release_context.py     # Release-trigger normalization helper
 │       └── setup-branch-protection.sh     # Setup script
 ├── notes/
 │   ├── .gitkeep                   # Keeps the committed notes directory in the template
@@ -149,6 +165,26 @@ python-project-template/
 - **CI_RUNNER** template variable sets the default runner target
 - **infra/home-worker/ci_runner_setup.yml** provides a Linux runner bootstrap skeleton
 - **docs/CI_RUNNER.md** explains GitHub-hosted vs self-hosted usage and runner-as-contract guidance
+
+### Release Workflow Skeleton
+
+- **release.yml** supports `workflow_dispatch` and `release: published` triggers
+- **resolve_release_context.py** normalizes trigger-specific metadata into stable outputs
+- **scripts/redeploy.sh** selects the appropriate Ansible playbook for `hetzner` or `home_worker`
+- **scripts/release_smoke_check.sh** performs generic HTTP checks with an optional version/ref assertion
+- **docs/RELEASE_WORKFLOW.md** documents operator usage, required secrets, and the release-body deployment status section
+- **docs/DEPLOYMENT.md** documents manual deploy and rollback commands
+
+Recommended GitHub Secrets for the release pipeline:
+
+- `DEPLOY_SSH_PRIVATE_KEY`
+- `DEPLOY_KNOWN_HOSTS`
+- `HETZNER_INVENTORY`
+- `HETZNER_SECRETS_YAML`
+- `HETZNER_BASE_URL`
+- `HOME_WORKER_INVENTORY`
+- `HOME_WORKER_SECRETS_YAML`
+- `HOME_WORKER_BASE_URL`
 
 ### Agent Guidance And Session Notes
 
@@ -204,6 +240,8 @@ See `docs/BRANCH_PROTECTION.md` for full documentation.
 - `docs/AI_SKILLS.md` - Canonical AI skills structure and deploy workflow
 - `docs/CI.md` - CI/CD pipeline documentation
 - `docs/CI_RUNNER.md` - Self-hosted runner operations and CI image contract
+- `docs/RELEASE_WORKFLOW.md` - Release deployment workflow documentation
+- `docs/DEPLOYMENT.md` - Manual deployment and rollback runbook
 - `docs/SETUP.md` - Installation and configuration guide
 - `docs/ARCHITECTURE.md` - Technical architecture (placeholder)
 - `docs/BRANCH_PROTECTION.md` - Branch protection rules documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,27 @@ This document describes the technical architecture of {{PROJECT_NAME}}.
 
 [High-level description of the system architecture]
 
+## Delivery And Deployment Control Plane
+
+The template now includes a deployment control plane alongside the application scaffold:
+
+- `.github/workflows/release.yml` is the operator entry point for manual and release-driven deployments
+- `scripts/github/resolve_release_context.py` converts trigger-specific GitHub metadata into stable deployment inputs
+- `scripts/redeploy.sh` and `scripts/release_smoke_check.sh` define the handoff between GitHub Actions and the infrastructure playbooks
+- `infra/hetzner/`, `infra/home-worker/`, and `infra/site/` provide the inventory, secrets, and orchestration skeletons that projects customize per environment
+
+```mermaid
+flowchart LR
+    A["workflow_dispatch / release: published"] --> B["resolve_release_context.py"]
+    B --> C["tag create or verify"]
+    C --> D["GitHub Release status update"]
+    D --> E["materialize SSH, inventory, secrets"]
+    E --> F["scripts/redeploy.sh"]
+    F --> G["Ansible playbooks under infra/"]
+    G --> H["scripts/release_smoke_check.sh"]
+    H --> I["success/failure status update on Release"]
+```
+
 ## System Components
 
 ### Component Diagram

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,10 +1,10 @@
 # Deployment
-
-This repository includes deployment-facing skeletons rather than a project-specific deploy implementation.
+This repository includes deployment-facing skeletons rather than a project-specific deploy implementation. Use this document for both deployment conventions and the manual runbook that matches the release automation skeleton.
 
 ## Service Naming
 
 When deploying with `systemd`, keep unit names aligned with the observability conventions described in [OBSERVABILITY.md](OBSERVABILITY.md):
+
 - `{{PROJECT_NAME}}.service`
 - `{{PROJECT_NAME}}-<job>.service`
 - `{{PROJECT_NAME}}-<job>.timer`
@@ -22,3 +22,88 @@ If your deployment ships journald logs into Loki, prefer the `component="{{PROJE
 ## Graceful Shutdown
 
 Long-running tasks should use a longer `TimeoutStopSec=` than the systemd default so in-flight work can finalize and write any session artifacts before forceful termination.
+
+## Manual Deployment Runbook
+
+## Files And Directories
+
+- `.github/workflows/release.yml`: orchestration entry point
+- `scripts/github/resolve_release_context.py`: trigger normalization helper
+- `scripts/redeploy.sh`: wrapper around the target-specific Ansible playbook
+- `scripts/release_smoke_check.sh`: post-deploy HTTP smoke checks
+- `infra/hetzner/`: VPS provisioning skeleton and example inventory/secrets
+- `infra/home-worker/`: worker/runner deployment skeleton and example inventory/secrets
+- `infra/site/`: site deployment orchestration playbooks
+
+## Manual Deployment
+
+### 1. Prepare local files from the examples
+
+```bash
+cp infra/hetzner/inventory.local.ini.example infra/hetzner/inventory.local.ini
+cp infra/hetzner/secrets.yml.example infra/hetzner/secrets.yml
+```
+
+Or for the home-worker target:
+
+```bash
+cp infra/home-worker/inventory.local.ini.example infra/home-worker/inventory.local.ini
+cp infra/home-worker/secrets.yml.example infra/home-worker/secrets.yml
+```
+
+### 2. Run the redeploy wrapper
+
+Hetzner / site target:
+
+```bash
+./scripts/redeploy.sh --target hetzner --deploy-ref <tag-or-commit>
+```
+
+Home-worker target:
+
+```bash
+./scripts/redeploy.sh --target home_worker --deploy-ref <tag-or-commit>
+```
+
+### 3. Run smoke checks
+
+```bash
+./scripts/release_smoke_check.sh --base-url https://example.com --smoke-level basic
+./scripts/release_smoke_check.sh --base-url https://example.com --smoke-level extended --expected-ref <tag-or-commit>
+```
+
+## Rollback
+
+The skeleton rollback path is "redeploy the previous known-good ref":
+
+```bash
+./scripts/redeploy.sh --target hetzner --deploy-ref <previous-tag>
+./scripts/release_smoke_check.sh --base-url https://example.com --smoke-level basic --expected-ref <previous-tag>
+```
+
+If your real deployment process includes migrations, data backfills, or asset versioning, document the rollback-specific steps inside the target playbooks before relying on this runbook operationally.
+
+## Secrets Management
+
+Do not commit live inventory or secrets files.
+
+- committed examples end in `.example`
+- live files are ignored in `.gitignore`
+- release automation expects the live file contents to arrive from GitHub Secrets
+
+Suggested GitHub Secrets:
+
+- `DEPLOY_SSH_PRIVATE_KEY`
+- `DEPLOY_KNOWN_HOSTS`
+- `HETZNER_INVENTORY`
+- `HETZNER_SECRETS_YAML`
+- `HETZNER_BASE_URL`
+- `HOME_WORKER_INVENTORY`
+- `HOME_WORKER_SECRETS_YAML`
+- `HOME_WORKER_BASE_URL`
+
+## Operator Notes
+
+- Keep `.github/workflows/release.yml`, the example inventory files, and the real playbooks aligned when you rename groups or paths.
+- `scripts/redeploy.sh` currently assumes `hetzner` maps to `infra/site/redeploy.yml` and `home_worker` maps to `infra/home-worker/redeploy.yml`.
+- `scripts/release_smoke_check.sh` only performs generic HTTP checks; most real projects should customize the extended check to hit an application-specific version or build endpoint.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,7 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 **For Users:**
 - [Getting Started](#getting-started) - Start here if you're new
 - [Setup Guide](#setup-guides) - Configure your environment
+- [Release Workflow](#operations) - Run a release deployment
 - [Session Notes](#project-history) - Learn the notes convention
 
 **For Developers:**
@@ -50,9 +51,14 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Structured logging and operator observability patterns
 - systemd naming, Loki integration, and session-artifact guidance
 
+**[RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md)**
+- Release automation trigger model
+- Deployment status updates on GitHub Releases
+- Required secrets and troubleshooting guidance
+
 **[DEPLOYMENT.md](DEPLOYMENT.md)**
-- Deployment conventions and systemd integration notes
-- Cross-links for release metadata and observability setup
+- Deployment conventions plus manual deployment and rollback runbook
+- Cross-links for release metadata, observability, and target playbooks
 
 ---
 
@@ -103,8 +109,32 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Two-layer observability model and operator runbook
 - Health endpoint patterns and useful LogQL queries
 
+**[RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md)**
+- Release deployment workflow structure
+- Trigger normalization and release-body status updates
+- Deployment troubleshooting checklist
+
 **[DEPLOYMENT.md](DEPLOYMENT.md)**
-- Deployment skeleton and links to service observability conventions
+- Deployment conventions, rollback path, and secrets-handling notes
+- Target/playbook alignment plus service observability links
+
+---
+
+## Operations
+
+**[OBSERVABILITY.md](OBSERVABILITY.md)**
+- Health endpoint, logging, and Loki query guidance
+- systemd naming and session-artifact conventions
+
+**[RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md)**
+- Release workflow triggers and required GitHub Secrets
+- Deployment status section written back to GitHub Releases
+- Troubleshooting steps for failed or skipped deploys
+
+**[DEPLOYMENT.md](DEPLOYMENT.md)**
+- Manual deployment and rollback commands
+- Inventory and secrets conventions
+- Follow-up customization guidance for target playbooks
 
 ---
 
@@ -144,7 +174,8 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 | [CI.md](CI.md) | CI/CD pipeline and development workflow | Developers |
 | [CI_RUNNER.md](CI_RUNNER.md) | Self-hosted runner operations and CI image contract | Developers, operators |
 | [OBSERVABILITY.md](OBSERVABILITY.md) | Logging, health, Loki, and operator runbook patterns | Developers, operators |
-| [DEPLOYMENT.md](DEPLOYMENT.md) | Deployment conventions and observability cross-links | Developers, operators |
+| [RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md) | Release deployment automation guide | Developers, operators |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Deployment conventions plus runbook and rollback notes | Developers, operators |
 | [AGENTS.md](../AGENTS.md) | Coding-agent workflow and guardrails | Claude Code, Codex, other agents |
 | [notes/README.md](../notes/README.md) | Session-notes convention and templates | Developers |
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -1,0 +1,96 @@
+# Release Workflow
+
+This guide documents the template release automation in `.github/workflows/release.yml`.
+
+## What It Does
+
+The release workflow provides a deployment-oriented automation path that:
+
+- accepts manual `workflow_dispatch` runs for controlled deployments
+- reacts to `release: published` events for release-driven rollouts
+- authorizes the repository owner for user-owned repos and admin collaborators for organization-owned repos
+- serializes deployments with a global concurrency lock
+- verifies or creates the requested release tag before deployment
+- records deployment state back onto the GitHub Release body
+- materializes inventories and secrets from GitHub Secrets instead of tracking live credentials in git
+
+## Triggers
+
+### Manual dispatch
+
+Use `Actions -> Release Deployment -> Run workflow` when you want to choose:
+
+- `ref`: branch, tag, or commit to deploy
+- `release_tag`: tag to create or verify
+- `target`: `hetzner` or `home_worker`
+- `smoke_level`: `basic` or `extended`
+
+### Published release
+
+Publishing a GitHub Release also triggers the workflow. In this path:
+
+- `release.tag_name` becomes the deployment tag
+- the published tag itself becomes the deployment ref
+- target defaults to `hetzner`
+- smoke level defaults to `basic`
+
+## Re-Entry Protection
+
+Manual workflow runs can create or update a GitHub Release. To avoid double deployment, the release body includes this marker:
+
+```html
+<!-- {{PROJECT_NAME}}-release-origin: workflow_dispatch -->
+```
+
+When the later `release: published` event sees that marker, the workflow exits without running the deploy a second time.
+
+## Required GitHub Secrets
+
+Common secrets:
+
+- `DEPLOY_SSH_PRIVATE_KEY`
+- `DEPLOY_KNOWN_HOSTS`
+
+Target-specific secrets:
+
+| Target | Required secrets |
+|--------|------------------|
+| `hetzner` | `HETZNER_INVENTORY`, `HETZNER_SECRETS_YAML`, `HETZNER_BASE_URL` |
+| `home_worker` | `HOME_WORKER_INVENTORY`, `HOME_WORKER_SECRETS_YAML`, `HOME_WORKER_BASE_URL` |
+
+Recommended contents:
+
+- `*_INVENTORY`: the literal contents of `inventory.local.ini`
+- `*_SECRETS_YAML`: the literal YAML contents of `secrets.yml`
+- `*_BASE_URL`: the externally reachable URL used by `scripts/release_smoke_check.sh`
+
+## Execution Flow
+
+1. Repair the self-hosted runner workspace before checkout with a regex guard.
+2. Check out the repository into `repo/`.
+3. Resolve a stable release context via `scripts/github/resolve_release_context.py`.
+4. Verify an existing release tag or create and push it when missing.
+5. Upsert the GitHub Release body with an in-progress deployment status block.
+6. Fail fast when the target's required secrets are not configured.
+7. Install `ansible-core` via `apt` when available or `pip --user` as a fallback.
+8. Write SSH material, inventory, and `secrets.yml` onto disk.
+9. Validate secrets parsing with a local Ansible command before deployment.
+10. Run `scripts/redeploy.sh`.
+11. Run `scripts/release_smoke_check.sh`.
+12. Update the GitHub Release body with `success` or `failure`.
+
+## Troubleshooting
+
+- If the workflow refuses to clean the workspace, inspect the self-hosted runner's `GITHUB_WORKSPACE` path and adjust the regex guard deliberately.
+- If Ansible installation falls back to `pip --user`, ensure `$HOME/.local/bin` is available to later steps.
+- If the workflow fails in the secrets pre-flight step, add the missing GitHub Secrets before retrying.
+- If `extended` smoke checks fail, confirm your application exposes a version endpoint and that the response contains the deployed ref or version string.
+
+## Follow-Up Customization
+
+The template ships only a skeleton. Before first production use:
+
+- replace the placeholder tasks in `infra/hetzner/`, `infra/home-worker/`, and `infra/site/`
+- align inventory host groups with your actual playbooks
+- adapt `scripts/release_smoke_check.sh` to your service's health and version endpoints
+- tighten or expand the target list if your project has more deployment environments

--- a/infra/hetzner/inventory.local.ini.example
+++ b/infra/hetzner/inventory.local.ini.example
@@ -1,0 +1,5 @@
+[app]
+vps-1 ansible_host=203.0.113.10 ansible_user=deploy
+
+[all:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/infra/hetzner/provision_vps.yml
+++ b/infra/hetzner/provision_vps.yml
@@ -1,0 +1,10 @@
+---
+- name: Hetzner VPS provisioning skeleton
+  hosts: app
+  become: true
+  tasks:
+    - name: Explain what this playbook should provision
+      ansible.builtin.debug:
+        msg:
+          - "Placeholder for base OS hardening, package install, and runtime bootstrap."
+          - "Add firewall, users, directories, and application prerequisites for your VPS."

--- a/infra/hetzner/secrets.yml.example
+++ b/infra/hetzner/secrets.yml.example
@@ -1,0 +1,5 @@
+---
+# Copy to secrets.yml through GitHub Secrets materialization in release.yml.
+app_env: production
+deploy_user: deploy
+app_repo: git@github.com:{{GITHUB_OWNER}}/{{PROJECT_NAME}}.git

--- a/infra/home-worker/deploy_target_setup.yml
+++ b/infra/home-worker/deploy_target_setup.yml
@@ -1,0 +1,10 @@
+---
+- name: Home-worker deployment target bootstrap skeleton
+  hosts: workers
+  become: true
+  tasks:
+    - name: Explain what this playbook should provision
+      ansible.builtin.debug:
+        msg:
+          - "Placeholder for worker runtime bootstrap and service installation."
+          - "Add package installs, app directories, systemd units, and SSH trust as needed."

--- a/infra/home-worker/inventory.local.ini.example
+++ b/infra/home-worker/inventory.local.ini.example
@@ -1,0 +1,5 @@
+[workers]
+worker-1 ansible_host=192.0.2.20 ansible_user=deploy
+
+[all:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/infra/home-worker/redeploy.yml
+++ b/infra/home-worker/redeploy.yml
@@ -1,0 +1,13 @@
+---
+- name: Home-worker redeploy skeleton
+  hosts: workers
+  become: true
+  vars:
+    deploy_ref: "{{ deploy_ref | default('HEAD') }}"
+  tasks:
+    - name: Confirm redeploy inputs
+      ansible.builtin.debug:
+        msg:
+          - "Home-worker redeploy placeholder"
+          - "Requested ref: {{ deploy_ref }}"
+          - "Implement fetch/reset/service-restart steps for your runtime."

--- a/infra/home-worker/secrets.yml.example
+++ b/infra/home-worker/secrets.yml.example
@@ -1,0 +1,4 @@
+---
+# Copy to secrets.yml through GitHub Secrets materialization in release.yml.
+worker_env: production
+deploy_user: deploy

--- a/infra/site/redeploy.yml
+++ b/infra/site/redeploy.yml
@@ -1,0 +1,15 @@
+---
+- name: Site redeploy skeleton
+  hosts: app
+  become: true
+  vars:
+    deploy_ref: "{{ deploy_ref | default('HEAD') }}"
+    deploy_target: "{{ deploy_target | default('hetzner') }}"
+  tasks:
+    - name: Confirm redeploy inputs
+      ansible.builtin.debug:
+        msg:
+          - "Site redeploy placeholder"
+          - "Target: {{ deploy_target }}"
+          - "Requested ref: {{ deploy_ref }}"
+          - "Implement checkout, dependency install, migration, and service-restart steps."

--- a/scripts/github/resolve_release_context.py
+++ b/scripts/github/resolve_release_context.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Normalize GitHub release trigger context into stable workflow outputs."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+DEFAULT_TARGET = "hetzner"
+DEFAULT_SMOKE_LEVEL = "basic"
+
+
+@dataclass(frozen=True)
+class ReleaseContext:
+    """Stable deployment inputs shared by manual and release-driven workflows."""
+
+    trigger: str
+    release_tag: str
+    deploy_ref: str
+    target: str
+    smoke_level: str
+    release_name: str
+    release_id: str
+
+    def as_outputs(self) -> dict[str, str]:
+        """Render context values for GitHub Actions outputs."""
+        return {
+            "trigger": self.trigger,
+            "release_tag": self.release_tag,
+            "deploy_ref": self.deploy_ref,
+            "target": self.target,
+            "smoke_level": self.smoke_level,
+            "release_name": self.release_name,
+            "release_id": self.release_id,
+        }
+
+
+def _normalize_text(value: Any) -> str:
+    """Trim arbitrary values to a usable string."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _manual_input(name: str, explicit_value: str | None, payload: Mapping[str, Any]) -> str:
+    """Read workflow-dispatch inputs from env overrides or the event payload."""
+    if explicit_value and explicit_value.strip():
+        return explicit_value.strip()
+    inputs = payload.get("inputs")
+    if isinstance(inputs, Mapping):
+        return _normalize_text(inputs.get(name))
+    return ""
+
+
+def load_event_payload(event_path: str | None) -> dict[str, Any]:
+    """Load the GitHub Actions event payload when available."""
+    if not event_path:
+        return {}
+    path = Path(event_path)
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if isinstance(payload, dict):
+        return payload
+    raise ValueError("GitHub event payload must be a JSON object.")
+
+
+def resolve_context(
+    *,
+    event_name: str,
+    payload: Mapping[str, Any],
+    github_ref_name: str = "",
+    github_sha: str = "",
+    manual_ref: str | None = None,
+    manual_release_tag: str | None = None,
+    manual_target: str | None = None,
+    manual_smoke_level: str | None = None,
+) -> ReleaseContext:
+    """Resolve the deployment context for the supported GitHub trigger types."""
+    if event_name == "workflow_dispatch":
+        release_tag = _manual_input("release_tag", manual_release_tag, payload)
+        if not release_tag:
+            raise ValueError("workflow_dispatch requires a release_tag input.")
+
+        deploy_ref = (
+            _manual_input("ref", manual_ref, payload) or _normalize_text(github_ref_name) or _normalize_text(github_sha)
+        )
+        if not deploy_ref:
+            raise ValueError("workflow_dispatch requires a deploy ref or GitHub ref context.")
+
+        target = _manual_input("target", manual_target, payload) or DEFAULT_TARGET
+        smoke_level = _manual_input("smoke_level", manual_smoke_level, payload) or DEFAULT_SMOKE_LEVEL
+        return ReleaseContext(
+            trigger="workflow_dispatch",
+            release_tag=release_tag,
+            deploy_ref=deploy_ref,
+            target=target,
+            smoke_level=smoke_level,
+            release_name=release_tag,
+            release_id="",
+        )
+
+    if event_name == "release":
+        action = _normalize_text(payload.get("action"))
+        if action and action != "published":
+            raise ValueError(f"Unsupported release action: {action}")
+
+        release_payload = payload.get("release")
+        if not isinstance(release_payload, Mapping):
+            raise ValueError("release event payload is missing the release object.")
+
+        release_tag = _normalize_text(release_payload.get("tag_name"))
+        if not release_tag:
+            raise ValueError("release event payload is missing release.tag_name.")
+
+        deploy_ref = release_tag
+        release_name = _normalize_text(release_payload.get("name")) or release_tag
+        return ReleaseContext(
+            trigger="release",
+            release_tag=release_tag,
+            deploy_ref=deploy_ref,
+            target=DEFAULT_TARGET,
+            smoke_level=DEFAULT_SMOKE_LEVEL,
+            release_name=release_name,
+            release_id=_normalize_text(release_payload.get("id")),
+        )
+
+    raise ValueError(f"Unsupported GitHub event: {event_name}")
+
+
+def write_outputs(outputs: Mapping[str, str], output_path: str | None) -> None:
+    """Write key-value outputs in the format GitHub Actions expects."""
+    lines = [f"{key}={value}" for key, value in outputs.items()]
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+        return
+    print("\n".join(lines))
+
+
+def main() -> int:
+    """Entry point for GitHub Actions."""
+    payload = load_event_payload(os.environ.get("GITHUB_EVENT_PATH"))
+    context = resolve_context(
+        event_name=os.environ.get("GITHUB_EVENT_NAME", ""),
+        payload=payload,
+        github_ref_name=os.environ.get("GITHUB_REF_NAME", ""),
+        github_sha=os.environ.get("GITHUB_SHA", ""),
+        manual_ref=os.environ.get("INPUT_REF"),
+        manual_release_tag=os.environ.get("INPUT_RELEASE_TAG"),
+        manual_target=os.environ.get("INPUT_TARGET"),
+        manual_smoke_level=os.environ.get("INPUT_SMOKE_LEVEL"),
+    )
+    write_outputs(context.as_outputs(), os.environ.get("GITHUB_OUTPUT"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/redeploy.sh --target <hetzner|home_worker> --deploy-ref <ref> [--inventory <path>] [--secrets-file <path>]
+EOF
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+target=""
+deploy_ref=""
+inventory_path=""
+secrets_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      target="${2:-}"
+      shift 2
+      ;;
+    --deploy-ref)
+      deploy_ref="${2:-}"
+      shift 2
+      ;;
+    --inventory)
+      inventory_path="${2:-}"
+      shift 2
+      ;;
+    --secrets-file)
+      secrets_path="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${target}" || -z "${deploy_ref}" ]]; then
+  usage >&2
+  exit 1
+fi
+
+case "${target}" in
+  hetzner)
+    playbook_path="${repo_root}/infra/site/redeploy.yml"
+    default_inventory="${repo_root}/infra/hetzner/inventory.local.ini"
+    default_secrets="${repo_root}/infra/hetzner/secrets.yml"
+    ;;
+  home_worker)
+    playbook_path="${repo_root}/infra/home-worker/redeploy.yml"
+    default_inventory="${repo_root}/infra/home-worker/inventory.local.ini"
+    default_secrets="${repo_root}/infra/home-worker/secrets.yml"
+    ;;
+  *)
+    echo "Unsupported target: ${target}" >&2
+    exit 1
+    ;;
+esac
+
+inventory_path="${inventory_path:-${default_inventory}}"
+secrets_path="${secrets_path:-${default_secrets}}"
+
+if [[ ! -f "${playbook_path}" ]]; then
+  echo "Missing playbook: ${playbook_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${inventory_path}" ]]; then
+  echo "Missing inventory file: ${inventory_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${secrets_path}" ]]; then
+  echo "Missing secrets file: ${secrets_path}" >&2
+  exit 1
+fi
+
+ansible-playbook \
+  -i "${inventory_path}" \
+  "${playbook_path}" \
+  --extra-vars "@${secrets_path}" \
+  --extra-vars "deploy_target=${target} deploy_ref=${deploy_ref}"

--- a/scripts/release_smoke_check.sh
+++ b/scripts/release_smoke_check.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/release_smoke_check.sh --base-url <url> --smoke-level <basic|extended> [--expected-ref <ref>]
+EOF
+}
+
+base_url=""
+smoke_level=""
+expected_ref=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url)
+      base_url="${2:-}"
+      shift 2
+      ;;
+    --smoke-level)
+      smoke_level="${2:-}"
+      shift 2
+      ;;
+    --expected-ref)
+      expected_ref="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${base_url}" || -z "${smoke_level}" ]]; then
+  usage >&2
+  exit 1
+fi
+
+case "${smoke_level}" in
+  basic|extended)
+    ;;
+  *)
+    echo "Unsupported smoke level: ${smoke_level}" >&2
+    exit 1
+    ;;
+esac
+
+curl --fail --silent --show-error --location --max-time 20 "${base_url}" >/dev/null
+
+if [[ "${smoke_level}" == "extended" ]]; then
+  version_endpoint="${VERSION_ENDPOINT_PATH:-/version}"
+  version_body="$(curl --fail --silent --show-error --location --max-time 20 "${base_url%/}${version_endpoint}")"
+
+  if [[ -n "${expected_ref}" && "${version_body}" != *"${expected_ref}"* ]]; then
+    echo "Version endpoint did not include expected ref ${expected_ref}." >&2
+    exit 1
+  fi
+fi

--- a/tests/test_resolve_release_context.py
+++ b/tests/test_resolve_release_context.py
@@ -1,0 +1,75 @@
+"""Tests for the release context resolver helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "github" / "resolve_release_context.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("resolve_release_context", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+resolve_release_context = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = resolve_release_context
+MODULE_SPEC.loader.exec_module(resolve_release_context)
+
+
+def test_resolve_context_for_manual_dispatch_uses_inputs() -> None:
+    """Manual workflow inputs should drive the normalized outputs."""
+    context = resolve_release_context.resolve_context(
+        event_name="workflow_dispatch",
+        payload={
+            "inputs": {
+                "ref": "release/next",
+                "release_tag": "v1.2.3",
+                "target": "home_worker",
+                "smoke_level": "extended",
+            }
+        },
+        github_ref_name="main",
+        github_sha="abc123",
+    )
+
+    assert context.trigger == "workflow_dispatch"
+    assert context.release_tag == "v1.2.3"
+    assert context.deploy_ref == "release/next"
+    assert context.target == "home_worker"
+    assert context.smoke_level == "extended"
+
+
+def test_resolve_context_for_manual_dispatch_falls_back_to_defaults() -> None:
+    """Manual dispatch should fill in target/smoke defaults when omitted."""
+    context = resolve_release_context.resolve_context(
+        event_name="workflow_dispatch",
+        payload={"inputs": {"release_tag": "v2.0.0"}},
+        github_ref_name="main",
+    )
+
+    assert context.deploy_ref == "main"
+    assert context.target == resolve_release_context.DEFAULT_TARGET
+    assert context.smoke_level == resolve_release_context.DEFAULT_SMOKE_LEVEL
+
+
+def test_resolve_context_for_published_release_uses_release_tag_as_deploy_ref() -> None:
+    """Published releases should deploy the published tag, not target_commitish."""
+    context = resolve_release_context.resolve_context(
+        event_name="release",
+        payload={
+            "action": "published",
+            "release": {
+                "id": 123,
+                "tag_name": "v3.4.5",
+                "target_commitish": "deadbeef",
+                "name": "Version 3.4.5",
+            },
+        },
+    )
+
+    assert context.trigger == "release"
+    assert context.release_tag == "v3.4.5"
+    assert context.deploy_ref == "v3.4.5"
+    assert context.release_name == "Version 3.4.5"
+    assert context.release_id == "123"
+    assert context.target == resolve_release_context.DEFAULT_TARGET
+    assert context.smoke_level == resolve_release_context.DEFAULT_SMOKE_LEVEL


### PR DESCRIPTION
## Summary
- add a release deployment workflow skeleton with tag verification, release-body status updates, secrets materialization, ansible bootstrap, and smoke checks
- add helper scripts plus Hetzner/home-worker/site Ansible skeletons and example inventories/secrets
- document the release/deployment workflow in the template docs and add resolver tests

## Testing
- `source venv/bin/activate && pytest -c /dev/null tests -q`
- `bash -n scripts/redeploy.sh scripts/release_smoke_check.sh`
- YAML parse check for new workflow and playbooks

## Notes
- `pre-commit run --all-files` is currently blocked in the template repo because `.pre-commit-config.yaml` contains unresolved template placeholders and cannot be parsed before rendering.

Closes #8