### PR TITLE
fix(ci): finish pending workflow action upgrades

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,7 +50,7 @@ jobs:
           echo "ref=$HEAD_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.pr-ref.outputs.ref || github.ref }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
           echo "ref=$HEAD_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.pr-ref.outputs.ref || github.ref }}


### PR DESCRIPTION
## Summary
- bump the remaining Claude workflows from `actions/checkout@v4` to `@v6`
- align all current checkout usage in repository workflows on `@v6`
- document that old Dependabot PRs `#2` and `#3` are now superseded by `main`

## Validation
- `git diff --check`
- `rg -n "actions/(checkout|setup-python)@|codecov/codecov-action@" .github/workflows -S`

## Notes
- `pre-commit` is not runnable in the raw template repository because `.pre-commit-config.yaml` still contains unresolved template placeholders such as `{{MAX_LINE_LENGTH}}`.