### PR TITLE
Add baseline security scanning to the template pipeline

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-max-line-length = {{MAX_LINE_LENGTH}}
+# TEMPLATE_VAR:MAX_LINE_LENGTH
+max-line-length = 127
 exclude =
     .git,
     __pycache__,
@@ -8,7 +9,8 @@ exclude =
     build,
     dist,
     *.egg-info
-max-complexity = {{MAX_COMPLEXITY}}
+# TEMPLATE_VAR:MAX_COMPLEXITY
+max-complexity = 10
 ignore =
     # Allow line breaks before binary operators (PEP 8 updated)
     W503,

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -2,7 +2,8 @@ name: Build CI Image
 
 on:
   push:
-    branches: [ {{MAIN_BRANCH}} ]
+    branches:
+      - "{{MAIN_BRANCH}}"
     paths:
       - 'infra/ci/Dockerfile'
       - 'requirements.txt'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,19 @@ name: CI
 
 on:
   push:
-    branches: [ {{MAIN_BRANCH}}, {{DEV_BRANCH}} ]
+    branches:
+      - "{{MAIN_BRANCH}}"
+      - "{{DEV_BRANCH}}"
   pull_request:
-    branches: [ {{MAIN_BRANCH}}, {{DEV_BRANCH}} ]
+    branches:
+      - "{{MAIN_BRANCH}}"
+      - "{{DEV_BRANCH}}"
   workflow_dispatch:
     inputs:
       runner_target:
         description: Runner target for this manual CI run
         required: false
-        default: {{CI_RUNNER}}
+        default: "{{CI_RUNNER}}"
         type: choice
         options:
           - github_hosted
@@ -28,7 +32,7 @@ permissions:
   pull-requests: read
 
 env:
-  DEFAULT_RUNNER: {{CI_RUNNER}}
+  DEFAULT_RUNNER: "{{CI_RUNNER}}"
 
 jobs:
   resolve-runner:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,74 @@
+name: Secret Scanning
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: secret-scanning-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+env:
+  GITLEAKS_VERSION: 8.30.1
+  GITLEAKS_LINUX_X64_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+
+jobs:
+  gitleaks:
+    name: Secret Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install pinned gitleaks binary
+        run: |
+          set -euo pipefail
+
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+
+          curl -sSL -o "${archive}" "${url}"
+          echo "${GITLEAKS_LINUX_X64_SHA256}  ${archive}" | sha256sum -c -
+
+          tar -xzf "${archive}" gitleaks LICENSE README.md
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+
+      - name: Scan git history with gitleaks
+        id: scan
+        continue-on-error: true
+        run: |
+          gitleaks git . \
+            --no-banner \
+            --redact=100 \
+            --report-format sarif \
+            --report-path gitleaks.sarif
+
+      - name: Upload redacted SARIF to GitHub code scanning when supported
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+
+      - name: Upload redacted gitleaks report artifact
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-sarif
+          path: gitleaks.sarif
+          if-no-files-found: error
+
+      - name: Fail when leaks are detected
+        if: steps.scan.outcome == 'failure'
+        run: |
+          echo "::error::Gitleaks detected potential secrets. Review the Secret Scanning job output and rotate or remove any exposed credentials."
+          exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+minimum_pre_commit_version: "3.6.0"
+
 repos:
   # Code formatting
   - repo: https://github.com/psf/black
@@ -19,7 +21,7 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
-        args: [--max-line-length={{MAX_LINE_LENGTH}}, --max-complexity={{MAX_COMPLEXITY}}]
+        # Uses settings from .flake8
 
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -27,7 +29,7 @@ repos:
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --strict, --explicit-package-bases]
-        files: ^{{SOURCE_DIR}}/
+        files: ^(src|{{SOURCE_DIR}})/
         additional_dependencies: [types-PyYAML]
 
   # Security checks
@@ -36,7 +38,7 @@ repos:
     hooks:
       - id: bandit
         args: [-ll]
-        exclude: ^(venv/|{{TEST_DIR}}/)
+        exclude: ^(venv/|tests/|{{TEST_DIR}}/)
 
   # Dependency vulnerability scanning
   - repo: https://github.com/pypa/pip-audit
@@ -44,6 +46,13 @@ repos:
     hooks:
       - id: pip-audit
         args: [--requirement, requirements.txt, --cache-dir, .pip-audit-cache]
+
+  # Secret scanning
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        args: [--no-banner]
 
   # Generic checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,8 @@ disable=
     W0212,  # protected-access
 
 [FORMAT]
-max-line-length={{MAX_LINE_LENGTH}}
+# TEMPLATE_VAR:MAX_LINE_LENGTH
+max-line-length=127
 indent-string='    '
 
 [BASIC]

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ This project uses:
 - **mypy** for type checking
 - **bandit** for security scanning
 - **pip-audit** for dependency vulnerability checking
+- **gitleaks** for secret detection in commits and repository history
 
-All checks run automatically via pre-commit hooks and CI.
+Baseline checks run automatically via pre-commit hooks and GitHub Actions.
 
 ## CI/CD
 
@@ -124,6 +125,7 @@ GitHub Actions runs the following checks on every push and PR:
 2. **Test**: pytest across Python {{PYTHON_VERSIONS}}
 3. **Coverage**: {{COVERAGE_THRESHOLD}}% minimum coverage
 4. **Security**: bandit and pip-audit
+5. **Secret scanning**: gitleaks against repository history with redacted reporting
 
 See [docs/CI.md](docs/CI.md) for details.
 
@@ -132,6 +134,7 @@ See [docs/CI.md](docs/CI.md) for details.
 - [Documentation Index](docs/INDEX.md) - All documentation
 - [Setup Guide](docs/SETUP.md) - Installation and configuration
 - [CI Documentation](docs/CI.md) - CI/CD pipeline details
+- [Security Baseline](docs/SECURITY_BASELINE.md) - Secret scanning and recommended GitHub security features
 - [AI Skills](docs/AI_SKILLS.md) - Canonical AI-skill source and deploy workflow
 
 ## Contributing

--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -61,6 +61,7 @@ python-project-template/
 │   ├── workflows/
 │   │   ├── ci.yml                 # Main CI pipeline
 │   │   ├── ci-image.yml           # Shared CI image build/publish workflow
+│   │   ├── gitleaks.yml           # Repository secret-scanning workflow
 │   │   ├── release.yml            # Manual + release-event deployment workflow
 │   │   ├── claude.yml             # Claude Code automation
 │   │   └── claude-code-review.yml # AI code review
@@ -85,6 +86,7 @@ python-project-template/
 │   ├── ARCHITECTURE.md            # Technical design
 │   ├── CI.md                      # CI/CD documentation
 │   ├── CI_RUNNER.md               # Self-hosted runner and CI image guide
+│   ├── SECURITY_BASELINE.md       # Secret scanning and GitHub security baseline
 │   ├── RELEASE_WORKFLOW.md        # Release deployment workflow guide
 │   ├── DEPLOYMENT.md              # Manual deployment runbook
 │   ├── BRANCH_PROTECTION.md       # Branch protection documentation
@@ -152,6 +154,7 @@ python-project-template/
 - **Test job**: pytest across Python 3.10, 3.11, 3.12 after coverage passes
 - **Coverage job**: Enforces coverage threshold with HTML reports
 - **Security job**: bandit and pip-audit scanning
+- **Secret-scanning workflow**: gitleaks on pushes, PRs, and manual dispatch
 - **Config validation**: YAML and Python syntax checks
 - **Smart skip logic**: docs-only diffs and merged-PR pushes to `main` skip heavy jobs but still report `CI Status Check`
 
@@ -206,22 +209,20 @@ Recommended GitHub Secrets for the release pipeline:
 
 ### Pre-commit Hooks
 
-9 hooks configured:
-1. Black (code formatting)
-2. isort (import sorting)
-3. flake8 (linting)
-4. mypy (type checking)
-5. bandit (security scanning)
-6. pip-audit (dependency vulnerabilities)
-7. trailing-whitespace
-8. end-of-file-fixer
-9. check-yaml
+The template includes formatting, linting, typing, dependency, secret-scanning, and generic hygiene hooks.
+
+Security-focused hooks include:
+- `bandit`
+- `pip-audit`
+- `gitleaks`
+- `detect-private-key`
 
 ### Branch Protection (`scripts/github/`)
 
 Automated branch protection configuration:
 
 - **Required status checks**: All CI jobs must pass
+- **Security gate**: `Secret Scanning` can be required alongside the CI aggregate checks
 - **Linear history**: No merge commits (squash or rebase only)
 - **Conversation resolution**: All review comments must be resolved
 - **Force push protection**: Prevents accidental history overwrites
@@ -243,6 +244,7 @@ See `docs/BRANCH_PROTECTION.md` for full documentation.
 - `docs/AI_SKILLS.md` - Canonical AI skills structure and deploy workflow
 - `docs/CI.md` - CI/CD pipeline documentation
 - `docs/CI_RUNNER.md` - Self-hosted runner operations and CI image contract
+- `docs/SECURITY_BASELINE.md` - Secret scanning baseline and GitHub security setup
 - `docs/RELEASE_WORKFLOW.md` - Release deployment workflow documentation
 - `docs/DEPLOYMENT.md` - Manual deployment and rollback runbook
 - `docs/SETUP.md` - Installation and configuration guide
@@ -310,6 +312,7 @@ After running `setup_template.py`:
 3. **Configure GitHub** (if using Claude workflows):
    - Add `CLAUDE_CODE_OAUTH_TOKEN` secret to repository
    - Enable GitHub Actions
+   - Review `docs/SECURITY_BASELINE.md` and enable GitHub secret scanning, push protection, and CodeQL where available
 
 4. **Start developing**:
    - Add your code to `src/`

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -57,6 +57,7 @@ All CI checks must pass before merging:
 - `Test Python 3.11` - Tests on Python 3.11
 - `Test Python 3.12` - Tests on Python 3.12
 - `Security Checks` - bandit and pip-audit gate
+- `Secret Scanning` - gitleaks repository-history secret scan
 - `Validate Configuration` - Configuration file validation
 - `CI Status Check` - Final CI status verification
 
@@ -126,6 +127,7 @@ The configuration file is located at `scripts/github/branch-protection-config.js
     - `Test Python 3.11`
     - `Test Python 3.12`
     - `Security Checks`
+    - `Secret Scanning`
     - `Validate Configuration`
     - `CI Status Check`
 - [x] Require conversation resolution before merging
@@ -153,6 +155,7 @@ gh api /repos/<owner>/<repo>/branches/main/protection --jq '.required_status_che
 #   "Test Python 3.11",
 #   "Test Python 3.12",
 #   "Security Checks",
+#   "Secret Scanning",
 #   "Validate Configuration",
 #   "CI Status Check"
 # ]
@@ -271,9 +274,12 @@ git push --force-with-lease origin your-branch
 - Deleting the main branch
 
 **Additional security measures:**
-- Enable GitHub's secret scanning
+- Enable GitHub's secret scanning and push protection
+- Enable CodeQL default setup when your repository plan supports it
 - Use signed commits for critical changes
 - Regularly rotate access tokens and secrets
+
+See [SECURITY_BASELINE.md](SECURITY_BASELINE.md) for the template's full repository-security baseline.
 
 ## Best Practices
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,6 +1,6 @@
 # CI/CD Pipeline Documentation
 
-This document describes the Continuous Integration pipeline for {{PROJECT_NAME}}, including the Docker CI image, runner-resolution workflow, and the local validation path that mirrors GitHub Actions.
+This document describes the Continuous Integration pipeline for {{PROJECT_NAME}}, including the Docker CI image, runner-resolution workflow, the companion secret-scanning workflow, and the local validation path that mirrors GitHub Actions.
 
 ## Overview
 
@@ -80,6 +80,19 @@ Purpose: validate YAML configuration and Python syntax.
 
 Purpose: aggregate job outcomes and publish the final required status, including intentional skip reasons.
 
+## Companion Security Workflow (`.github/workflows/gitleaks.yml`)
+
+The template also includes a dedicated `Secret Scanning` workflow for repository-level secret detection:
+
+- triggers on `push`, `pull_request`, and `workflow_dispatch`
+- checks out the full git history with `fetch-depth: 0`
+- installs a pinned `gitleaks` release and verifies its checksum
+- generates a redacted SARIF report
+- uploads the redacted SARIF artifact on every run
+- attempts a best-effort upload to GitHub code scanning when the repository supports SARIF ingestion
+
+This workflow is separate from `ci.yml` because secret scanning has different runtime and reporting needs than the containerized application checks.
+
 ## CI Image Workflow (`.github/workflows/ci-image.yml`)
 
 The CI image workflow rebuilds and publishes the shared image when these inputs change:
@@ -128,6 +141,8 @@ pytest {{TEST_DIR}}/ -v --cov={{SOURCE_DIR}} --cov-report=term-missing --cov-fai
 pytest {{TEST_DIR}}/ -v
 bandit -r {{SOURCE_DIR}}/ -ll
 pip-audit --requirement requirements.txt
+gitleaks dir . --no-banner --redact=100
+gitleaks git . --no-banner --redact=100
 ```
 
 ## Containerized CI Architecture
@@ -158,9 +173,11 @@ flowchart LR
 |------|---------|
 | `.github/workflows/ci.yml` | Main CI workflow |
 | `.github/workflows/ci-image.yml` | CI image build/publish workflow |
+| `.github/workflows/gitleaks.yml` | Repository secret-scanning workflow |
 | `infra/ci/Dockerfile` | Shared CI image definition |
 | `infra/ci/docker-compose.ci.yml` | Local container shell matching CI |
 | `infra/ci/build-and-push.sh` | Manual multi-arch build/push helper |
 | `docs/CI_RUNNER.md` | Self-hosted runner operations guidance |
+| `docs/SECURITY_BASELINE.md` | Secret scanning and GitHub security baseline |
 | `.pre-commit-config.yaml` | Local pre-commit checks |
 | `pyproject.toml` | Tool configurations |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -51,6 +51,10 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Structured logging and operator observability patterns
 - systemd naming, Loki integration, and session-artifact guidance
 
+**[SECURITY_BASELINE.md](SECURITY_BASELINE.md)**
+- Baseline secret scanning and repository security guidance
+- GitHub secret scanning, push protection, and CodeQL setup references
+
 **[RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md)**
 - Release automation trigger model
 - Deployment status updates on GitHub Releases
@@ -99,6 +103,10 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Local development workflow
 - Running CI checks locally
 - Troubleshooting CI failures
+
+**[SECURITY_BASELINE.md](SECURITY_BASELINE.md)**
+- Template-level secret scanning workflow and pre-commit baseline
+- Post-creation GitHub security features to enable
 
 **[CI_RUNNER.md](CI_RUNNER.md)**
 - GitHub-hosted vs self-hosted runner guidance
@@ -172,6 +180,7 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 | [AI_SKILLS.md](AI_SKILLS.md) | AI skill source, deploy, and starter-skill guide | Developers |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Technical architecture and design | Developers |
 | [CI.md](CI.md) | CI/CD pipeline and development workflow | Developers |
+| [SECURITY_BASELINE.md](SECURITY_BASELINE.md) | Secret scanning baseline and GitHub security setup | Developers, operators |
 | [CI_RUNNER.md](CI_RUNNER.md) | Self-hosted runner operations and CI image contract | Developers, operators |
 | [OBSERVABILITY.md](OBSERVABILITY.md) | Logging, health, Loki, and operator runbook patterns | Developers, operators |
 | [RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md) | Release deployment automation guide | Developers, operators |

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -1,0 +1,79 @@
+# Repository Security Baseline
+
+This template includes a baseline repository-security setup so new projects get secret detection and security guidance immediately after creation.
+
+## Included In The Template
+
+- `.github/workflows/gitleaks.yml` scans the full git history on `push`, `pull_request`, and `workflow_dispatch`.
+- `.pre-commit-config.yaml` includes an official `gitleaks` hook so obvious leaks are caught before they are pushed.
+- `.github/workflows/ci.yml` continues to run `bandit` and `pip-audit` for application-level and dependency-level checks.
+
+The `gitleaks` workflow installs a pinned upstream binary, verifies its SHA-256 checksum, redacts findings in logs, and writes a redacted SARIF report. The workflow always uploads the SARIF file as an artifact and attempts a best-effort upload to GitHub code scanning where that feature is available for the repository.
+
+## Recommended GitHub Features To Enable
+
+After creating a repository from this template, enable the following GitHub-native features where your repository plan supports them:
+
+1. Secret scanning
+2. Push protection
+3. CodeQL default setup
+
+These features are distinct:
+
+- `gitleaks` is repository-local scanning that runs in your workflow and pre-commit hooks.
+- GitHub secret scanning and push protection detect supported secret types in GitHub-hosted pushes and repository history.
+- CodeQL default setup is for code scanning, not secret detection.
+
+GitHub availability changes by repository type and plan, so verify current support in the official docs linked below before relying on a specific feature for a new private or organization-owned repository.
+
+## Local Secret Scanning
+
+Install hooks during bootstrap:
+
+```bash
+pre-commit install --install-hooks
+```
+
+For direct repository or history scans, install the `gitleaks` CLI separately. On macOS, one common option is:
+
+```bash
+brew install gitleaks
+```
+
+Scan the current working tree directly with `gitleaks`:
+
+```bash
+gitleaks dir . --no-banner --redact=100
+```
+
+Scan the full git history:
+
+```bash
+gitleaks git . --no-banner --redact=100
+```
+
+Generate a local redacted SARIF report:
+
+```bash
+gitleaks git . \
+  --no-banner \
+  --redact=100 \
+  --report-format sarif \
+  --report-path gitleaks.sarif
+```
+
+## Operational Notes
+
+- The pre-commit hook scans staged changes before commit.
+- Use the standalone `gitleaks` CLI, not `pre-commit run gitleaks --all-files`, when you want a full working-tree or full-history scan.
+- The GitHub Actions workflow scans repository history because leaked secrets often remain reachable in older commits even after a later cleanup.
+- If `gitleaks` reports a real secret, treat it as compromised: rotate it, remove it from code, and consider rewriting git history if exposure persisted in committed history.
+- If GitHub code scanning is unavailable for the repository, the workflow still preserves the redacted SARIF artifact in the Actions run.
+
+## References
+
+- [Gitleaks repository](https://github.com/gitleaks/gitleaks)
+- [GitHub: Enabling secret scanning for your repository](https://docs.github.com/en/code-security/secret-scanning/enabling-secret-scanning-features/enabling-secret-scanning-for-your-repository)
+- [GitHub: About push protection](https://docs.github.com/en/code-security/secret-scanning/introduction/about-push-protection)
+- [GitHub: About setup types for code scanning](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types)
+- [GitHub: Uploading a SARIF file to GitHub](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/uploading-a-sarif-file-to-github)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -140,6 +140,18 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+Because this template includes the official `gitleaks` hook, the `pre-commit>=3.6.0` requirement in `requirements-dev.txt` matters: modern `pre-commit` can bootstrap the hook's Go toolchain automatically.
+
+### Enable Repository Security Features
+
+After the repository exists on GitHub, review and enable the baseline security features described in [SECURITY_BASELINE.md](SECURITY_BASELINE.md):
+
+- secret scanning
+- push protection
+- CodeQL default setup
+
+These features are configured in GitHub, not in the local bootstrap commands above.
+
 ### Deploy AI Skills
 
 The template ships canonical AI skill sources under `ai-skills/` and a deploy flow that renders them to both Claude and Codex:
@@ -174,6 +186,7 @@ See [AI_SKILLS.md](AI_SKILLS.md) for the canonical source layout, starter skills
 Typical additions in this template include:
 - `git` and `gh` commands used during issue delivery
 - `pre-commit`, `pytest`, and static-analysis commands
+- `gitleaks` when you run manual repository scans outside pre-commit
 - `ansible-playbook` and the local AI-skills deploy wrapper
 - common filesystem inspection commands needed during template setup work
 
@@ -244,4 +257,5 @@ cp config/config.example.yaml config/config.yaml
 - Check the [Documentation Index](INDEX.md)
 - Review [notes/README.md](../notes/README.md) for note conventions
 - Review [CI documentation](CI.md) for testing issues
+- Review [SECURITY_BASELINE.md](SECURITY_BASELINE.md) for secret-scanning setup and GitHub security features
 - Open an issue on GitHub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = {{MAX_LINE_LENGTH}}
+line-length = 127  # TEMPLATE_VAR:MAX_LINE_LENGTH
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
@@ -15,7 +15,7 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
-line_length = {{MAX_LINE_LENGTH}}
+line_length = 127  # TEMPLATE_VAR:MAX_LINE_LENGTH
 skip_gitignore = true
 skip = [".venv", "venv", "build", "dist"]
 

--- a/scripts/github/branch-protection-config.json
+++ b/scripts/github/branch-protection-config.json
@@ -9,6 +9,7 @@
       "Test Python 3.11",
       "Test Python 3.12",
       "Security Checks",
+      "Secret Scanning",
       "Validate Configuration",
       "CI Status Check"
     ]

--- a/setup_template.py
+++ b/setup_template.py
@@ -9,6 +9,7 @@ Usage:
 """
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -186,6 +187,18 @@ def replace_in_file(file_path: Path, replacements: Dict[str, str]) -> bool:
         for var_name, value in replacements.items():
             pattern = "{{" + var_name + "}}"
             content = content.replace(pattern, value)
+            assignment_pattern = (
+                r"^(?P<prefix>\s*[^#\n=]+=\s*)(?P<current>[^#\n]+?)\s*#\s*TEMPLATE_VAR:"
+                rf"{re.escape(var_name)}(?P<newline>\n?)$"
+            )
+            content = re.sub(
+                assignment_pattern,
+                lambda match: f"{match.group('prefix')}{value}{match.group('newline')}",
+                content,
+                flags=re.MULTILINE,
+            )
+
+        content = render_template_assignment_markers(content, replacements)
 
         if content != original_content:
             file_path.write_text(content, encoding="utf-8")
@@ -194,6 +207,32 @@ def replace_in_file(file_path: Path, replacements: Dict[str, str]) -> bool:
     except Exception as e:
         print(f"  Warning: Could not process {file_path}: {e}")
         return False
+
+
+def render_template_assignment_markers(content: str, replacements: Dict[str, str]) -> str:
+    """Render standalone template markers that apply to the next assignment line."""
+    rendered_lines: List[str] = []
+    pending_var: Optional[str] = None
+
+    for line in content.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("# TEMPLATE_VAR:"):
+            pending_var = stripped.removeprefix("# TEMPLATE_VAR:").strip()
+            continue
+
+        if pending_var is not None:
+            value = replacements.get(pending_var)
+            assignment = re.match(r"(?P<prefix>\s*[^#\n=]+=\s*)(?P<current>.*?)(?P<newline>\n?)$", line)
+            if assignment is not None and value is not None:
+                rendered_lines.append(f"{assignment.group('prefix')}{value}{assignment.group('newline')}")
+            else:
+                rendered_lines.append(line)
+            pending_var = None
+            continue
+
+        rendered_lines.append(line)
+
+    return "".join(rendered_lines)
 
 
 def iter_additional_template_files(project_root: Path) -> List[Path]:

--- a/tests/test_github_mockup_issue_assets.py
+++ b/tests/test_github_mockup_issue_assets.py
@@ -60,7 +60,7 @@ def test_render_snippet_includes_selector_metadata() -> None:
     image = github_mockup_issue_assets.CapturedImage(
         slug="hero-card",
         selector=".hero-card",
-        path=Path("/tmp/hero-card.png"),
+        path=Path("artifacts/hero-card.png"),
     )
     rendered = github_mockup_issue_assets.render_snippet(
         [image],

--- a/tests/test_setup_template.py
+++ b/tests/test_setup_template.py
@@ -64,3 +64,35 @@ def test_ensure_claude_symlink_recreates_expected_symlink(tmp_path: Path) -> Non
     assert setup_template.ensure_claude_symlink(tmp_path) is True
     assert (tmp_path / "CLAUDE.md").is_symlink()
     assert (tmp_path / "CLAUDE.md").resolve() == (tmp_path / "AGENTS.md")
+
+
+def test_replace_in_file_renders_template_var_marker_values(tmp_path: Path) -> None:
+    config_file = tmp_path / "pyproject.toml"
+    config_file.write_text(
+        "[tool.black]\nline-length = 127  # TEMPLATE_VAR:MAX_LINE_LENGTH\n",
+        encoding="utf-8",
+    )
+
+    replaced = setup_template.replace_in_file(
+        config_file,
+        {"MAX_LINE_LENGTH": "99"},
+    )
+
+    assert replaced is True
+    assert config_file.read_text(encoding="utf-8") == "[tool.black]\nline-length = 99\n"
+
+
+def test_replace_in_file_renders_standalone_template_var_markers(tmp_path: Path) -> None:
+    config_file = tmp_path / ".flake8"
+    config_file.write_text(
+        "[flake8]\n# TEMPLATE_VAR:MAX_COMPLEXITY\nmax-complexity = 10\n",
+        encoding="utf-8",
+    )
+
+    replaced = setup_template.replace_in_file(
+        config_file,
+        {"MAX_COMPLEXITY": "12"},
+    )
+
+    assert replaced is True
+    assert config_file.read_text(encoding="utf-8") == "[flake8]\nmax-complexity = 12\n"


### PR DESCRIPTION
## Summary
- add a dedicated `gitleaks` GitHub Actions workflow for repository secret scanning with redacted SARIF output
- add the official `gitleaks` pre-commit hook and document the template security baseline, including GitHub secret scanning, push protection, and CodeQL setup
- make the raw template's config files parseable by local validation tools while preserving downstream templating through `setup_template.py`

## Validation
- `source venv/bin/activate && pytest`
- `source venv/bin/activate && pre-commit run --all-files`

Closes #24.
