### PR TITLE
ci: default generated workflows to Fargate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
         default: "{{CI_RUNNER}}"
         type: choice
         options:
+          - fargate
           - github_hosted
           - self_hosted_linux
           - self_hosted_linux_arm64
@@ -37,12 +38,10 @@ env:
 jobs:
   resolve-runner:
     name: Resolve Runner Target
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
     outputs:
       runner: ${{ steps.pick.outputs.runner }}
       target: ${{ steps.pick.outputs.target }}
-      container_options: ${{ steps.pick.outputs.container_options }}
-      ci_image: ${{ steps.pick.outputs.ci_image }}
       skip_full_ci: ${{ steps.classify.outputs.skip_full_ci }}
       skip_reason: ${{ steps.classify.outputs.skip_reason }}
     steps:
@@ -57,30 +56,29 @@ jobs:
           fi
 
           case "$TARGET" in
+            fargate)
+              echo 'runner=["self-hosted","fargate"]' >> "$GITHUB_OUTPUT"
+              echo 'target=fargate' >> "$GITHUB_OUTPUT"
+              ;;
             github_hosted)
               echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
               echo 'target=github_hosted' >> "$GITHUB_OUTPUT"
-              echo 'container_options=' >> "$GITHUB_OUTPUT"
               ;;
             self_hosted_linux)
               echo 'runner=["self-hosted","linux"]' >> "$GITHUB_OUTPUT"
               echo 'target=self_hosted_linux' >> "$GITHUB_OUTPUT"
-              echo 'container_options=--user 1001:1001' >> "$GITHUB_OUTPUT"
               ;;
             self_hosted_linux_arm64)
               echo 'runner=["self-hosted","linux","arm64"]' >> "$GITHUB_OUTPUT"
               echo 'target=self_hosted_linux_arm64' >> "$GITHUB_OUTPUT"
-              echo 'container_options=--user 1001:1001 --platform linux/arm64' >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "::warning::Unknown runner target '$TARGET'. Falling back to github_hosted."
-              echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
-              echo 'target=github_hosted' >> "$GITHUB_OUTPUT"
-              echo 'container_options=' >> "$GITHUB_OUTPUT"
+              echo "::warning::Unknown runner target '$TARGET'. Falling back to fargate."
+              echo 'runner=["self-hosted","fargate"]' >> "$GITHUB_OUTPUT"
+              echo 'target=fargate' >> "$GITHUB_OUTPUT"
               ;;
           esac
 
-          echo 'ci_image=ghcr.io/{{GITHUB_OWNER}}/{{PROJECT_NAME}}-ci:latest' >> "$GITHUB_OUTPUT"
           echo "Resolved runner target: $TARGET"
 
       - id: classify
@@ -237,9 +235,6 @@ jobs:
     defaults:
       run:
         working-directory: repo
-    container:
-      image: ${{ needs.resolve-runner.outputs.ci_image }}
-      options: ${{ needs.resolve-runner.outputs.container_options }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -248,6 +243,11 @@ jobs:
 
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/repo"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Create pinned lint tool venv
         run: |
@@ -320,9 +320,6 @@ jobs:
     defaults:
       run:
         working-directory: repo
-    container:
-      image: ${{ needs.resolve-runner.outputs.ci_image }}
-      options: ${{ needs.resolve-runner.outputs.container_options }}
     strategy:
       fail-fast: true
       matrix:
@@ -336,8 +333,16 @@ jobs:
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/repo"
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements-dev.txt
+
       - name: Run tests with coverage
-        run: python3.12 -m pytest {{TEST_DIR}}/ -v --cov={{SOURCE_DIR}} --cov-report=term-missing --cov-report=html --cov-report=xml --cov-fail-under={{COVERAGE_THRESHOLD}}
+        run: python -m pytest {{TEST_DIR}}/ -v --cov={{SOURCE_DIR}} --cov-report=term-missing --cov-report=html --cov-report=xml --cov-fail-under={{COVERAGE_THRESHOLD}}
 
       - name: Upload coverage HTML report
         if: always()
@@ -381,9 +386,6 @@ jobs:
     defaults:
       run:
         working-directory: repo
-    container:
-      image: ${{ needs.resolve-runner.outputs.ci_image }}
-      options: ${{ needs.resolve-runner.outputs.container_options }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -392,6 +394,14 @@ jobs:
 
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/repo"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install security tools
+        run: python -m pip install bandit==1.9.4 pip-audit==2.10.1
 
       - name: Run bandit security checks
         run: bandit -r {{SOURCE_DIR}}/ -ll
@@ -426,9 +436,6 @@ jobs:
     defaults:
       run:
         working-directory: repo
-    container:
-      image: ${{ needs.resolve-runner.outputs.ci_image }}
-      options: ${{ needs.resolve-runner.outputs.container_options }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Validate YAML configuration files
         run: |
-          python3.12 -c "
+          .lint-venv/bin/python -c "
           import sys
           import yaml
 
@@ -291,7 +291,7 @@ jobs:
           "
 
       - name: Check Python syntax
-        run: find {{SOURCE_DIR}} -name '*.py' -exec python3.12 -m py_compile {} +
+        run: find {{SOURCE_DIR}} -name '*.py' -exec .lint-venv/bin/python -m py_compile {} +
 
       - name: Cancel workflow after lint failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ env:
 jobs:
   resolve-runner:
     name: Resolve Runner Target
+    # TEMPLATE_VAR:CI_RUNNER_LABELS
     runs-on: [self-hosted, fargate]
     outputs:
       runner: ${{ steps.pick.outputs.runner }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   gitleaks:
     name: Secret Scanning
+    # TEMPLATE_VAR:CI_RUNNER_LABELS
     runs-on: [self-hosted, fargate]
     steps:
       - name: Checkout code

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   gitleaks:
     name: Secret Scanning
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -38,14 +38,14 @@ jobs:
           curl -sSL -o "${archive}" "${url}"
           echo "${GITLEAKS_LINUX_X64_SHA256}  ${archive}" | sha256sum -c -
 
-          tar -xzf "${archive}" gitleaks LICENSE README.md
-          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          tar -xzf "${archive}" gitleaks
+          chmod +x gitleaks
 
       - name: Scan git history with gitleaks
         id: scan
         continue-on-error: true
         run: |
-          gitleaks git . \
+          ./gitleaks git . \
             --no-banner \
             --redact=100 \
             --report-format sarif \

--- a/README.md
+++ b/README.md
@@ -122,10 +122,12 @@ Baseline checks run automatically via pre-commit hooks and GitHub Actions.
 GitHub Actions runs the following checks on every push and PR:
 
 1. **Lint**: Black, isort, flake8, mypy
-2. **Test**: pytest across Python {{PYTHON_VERSIONS}}
+2. **Test**: pytest on Python 3.12 with coverage enforcement
 3. **Coverage**: {{COVERAGE_THRESHOLD}}% minimum coverage
 4. **Security**: bandit and pip-audit
 5. **Secret scanning**: gitleaks against repository history with redacted reporting
+
+The generated workflow defaults to ephemeral ECS Fargate runners. Select `github_hosted` during template setup when the target account is not connected to the shared Fargate runner App.
 
 See [docs/CI.md](docs/CI.md) for details.
 

--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -160,12 +160,12 @@ python-project-template/
 ### Docker CI Environment (`infra/ci/`)
 
 - **Dockerfile**: Ubuntu 24.04 CI image with Python 3.10, 3.11, and 3.12 plus preinstalled CI tooling
-- **docker-compose.ci.yml**: Local shell into the same environment GitHub Actions uses
+- **docker-compose.ci.yml**: Optional multi-version local CI shell; native GitHub Actions jobs create fresh per-job Python environments
 - **build-and-push.sh**: Manual multi-platform build helper for GHCR
 
 ### Runner Support
 
-- **resolve-runner** output drives `runs-on: ${{ fromJSON(...) }}` in CI
+- **resolve-runner** starts on the labels selected during setup, and its output drives downstream `runs-on: ${{ fromJSON(...) }}` values
 - **CI_RUNNER** template variable sets the default runner target; it defaults to ephemeral Fargate
 - **infra/home-worker/ci_runner_setup.yml** provides a Linux runner bootstrap skeleton
 - **docs/CI_RUNNER.md** explains Fargate activation plus GitHub-hosted and persistent self-hosted fallbacks

--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -49,7 +49,7 @@ If you prefer to configure manually:
 | `{{TEST_DIR}}` | Test directory name | `tests` |
 | `{{MAIN_BRANCH}}` | Main branch name | `main` |
 | `{{DEV_BRANCH}}` | Development branch name | `develop` |
-| `{{CI_RUNNER}}` | Default CI runner target | `github_hosted` |
+| `{{CI_RUNNER}}` | Default CI runner target | `fargate` |
 
 `{{MAX_LINE_LENGTH}}` defaults to `127` because it aligns with the template's Black-based formatting and reduces unnecessary wrapping noise in pull requests on modern editor widths.
 
@@ -149,13 +149,12 @@ python-project-template/
 
 ### CI/CD Pipeline (`.github/workflows/ci.yml`)
 
-- **Resolve-runner job**: Selects GitHub-hosted vs self-hosted labels and skip mode
-- **Lint job**: Black, isort, flake8, mypy in the shared CI image
-- **Test job**: pytest across Python 3.10, 3.11, 3.12 after coverage passes
-- **Coverage job**: Enforces coverage threshold with HTML reports
+- **Resolve-runner job**: Selects Fargate, GitHub-hosted, or persistent self-hosted labels and skip mode
+- **Lint job**: Black, isort, flake8, and mypy on the resolved native runner
+- **Test job**: pytest on Python 3.12 with the coverage threshold and HTML reports
 - **Security job**: bandit and pip-audit scanning
 - **Secret-scanning workflow**: gitleaks on pushes, PRs, and manual dispatch
-- **Config validation**: YAML and Python syntax checks
+- **Config validation**: YAML and Python syntax checks in the lint job
 - **Smart skip logic**: docs-only diffs and merged-PR pushes to `main` skip heavy jobs but still report `CI Status Check`
 
 ### Docker CI Environment (`infra/ci/`)
@@ -164,12 +163,12 @@ python-project-template/
 - **docker-compose.ci.yml**: Local shell into the same environment GitHub Actions uses
 - **build-and-push.sh**: Manual multi-platform build helper for GHCR
 
-### Self-Hosted Runner Support
+### Runner Support
 
 - **resolve-runner** output drives `runs-on: ${{ fromJSON(...) }}` in CI
-- **CI_RUNNER** template variable sets the default runner target
+- **CI_RUNNER** template variable sets the default runner target; it defaults to ephemeral Fargate
 - **infra/home-worker/ci_runner_setup.yml** provides a Linux runner bootstrap skeleton
-- **docs/CI_RUNNER.md** explains GitHub-hosted vs self-hosted usage and runner-as-contract guidance
+- **docs/CI_RUNNER.md** explains Fargate activation plus GitHub-hosted and persistent self-hosted fallbacks
 
 ### Release Workflow Skeleton
 
@@ -279,9 +278,9 @@ cp .mcp.json.example .mcp.json
 
 Then customize `.mcp.json` for your own servers and credentials. The real `.mcp.json` stays ignored by git.
 
-### CI Image Bootstrap
+### Optional CI Image
 
-Before requiring the new containerized CI contexts in branch protection, publish the shared CI image at least once:
+Fargate CI installs tools directly and does not require the shared CI image. Publish it only when you want the optional local or persistent self-hosted container environment:
 
 ```bash
 ./infra/ci/build-and-push.sh
@@ -312,6 +311,7 @@ After running `setup_template.py`:
 3. **Configure GitHub** (if using Claude workflows):
    - Add `CLAUDE_CODE_OAUTH_TOKEN` secret to repository
    - Enable GitHub Actions
+   - Authorize the repository on the shared Fargate runner App, or select `github_hosted` during setup
    - Review `docs/SECURITY_BASELINE.md` and enable GitHub secret scanning, push protection, and CodeQL where available
 
 4. **Start developing**:
@@ -362,7 +362,8 @@ The template includes both `config/config.example.yaml` and `.env.example`.
 ### CI Runner Target
 
 - `{{CI_RUNNER}}` controls the default runner target used by `.github/workflows/ci.yml`.
-- Supported values are `github_hosted`, `self_hosted_linux`, and `self_hosted_linux_arm64`.
+- Supported values are `fargate`, `github_hosted`, `self_hosted_linux`, and `self_hosted_linux_arm64`.
+- Before using `fargate`, authorize the generated repository on the shared runner GitHub App as described in `docs/CI_RUNNER.md`.
 - Keep the workflow, `docs/CI_RUNNER.md`, and any self-hosted runner bootstrap playbooks aligned if you change the labels or targets.
 
 ## Troubleshooting

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -11,6 +11,7 @@ The CI workflow runs on pushes and pull requests targeting `{{MAIN_BRANCH}}` and
 ### Runner Resolution
 
 - `resolve-runner` decides which runner labels downstream jobs should use.
+- The resolver itself runs on the bootstrap labels selected during template setup, so a configured GitHub-hosted or persistent self-hosted fallback does not depend on Fargate.
 - The default target comes from `{{CI_RUNNER}}`.
 - Manual `workflow_dispatch` runs can override the target with:
   - `fargate`
@@ -78,7 +79,7 @@ The template also includes a dedicated `Secret Scanning` workflow for repository
 
 - triggers on `push`, `pull_request`, and `workflow_dispatch`
 - checks out the full git history with `fetch-depth: 0`
-- runs on an ephemeral `[self-hosted, fargate]` runner
+- runs on the runner selected during template setup (`[self-hosted, fargate]` by default)
 - installs a pinned `gitleaks` release and verifies its checksum
 - executes the workspace binary directly without `sudo`
 - generates a redacted SARIF report
@@ -107,7 +108,7 @@ Published platforms:
 
 ## Local Validation
 
-### Run the same CI image locally
+### Run the optional CI image locally
 
 ```bash
 docker build -t {{PROJECT_NAME}}-ci:test -f infra/ci/Dockerfile .
@@ -126,6 +127,8 @@ mypy --version
 pytest --version
 python3.12 -m pytest {{TEST_DIR}}/ -v --cov={{SOURCE_DIR}}
 ```
+
+This image is a convenient multi-version local toolchain. It is not identical to the native GitHub Actions environment, which installs dependencies into fresh per-job environments.
 
 ### Run the repository checks without Docker
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,10 +1,10 @@
 # CI/CD Pipeline Documentation
 
-This document describes the Continuous Integration pipeline for {{PROJECT_NAME}}, including the Docker CI image, runner-resolution workflow, the companion secret-scanning workflow, and the local validation path that mirrors GitHub Actions.
+This document describes the Continuous Integration pipeline for {{PROJECT_NAME}}, including ephemeral Fargate runners, runner resolution, the companion secret-scanning workflow, and local validation.
 
 ## Overview
 
-The CI workflow runs on pushes and pull requests targeting `{{MAIN_BRANCH}}` and `{{DEV_BRANCH}}`. It now uses a shared Docker image for the real checks instead of installing tools independently in every job.
+The CI workflow runs on pushes and pull requests targeting `{{MAIN_BRANCH}}` and `{{DEV_BRANCH}}`. New projects default to ephemeral ECS Fargate runners and install their Python toolchain directly in each job. GitHub-hosted and persistent self-hosted runners remain manual fallbacks.
 
 ## CI Jobs (`.github/workflows/ci.yml`)
 
@@ -13,11 +13,12 @@ The CI workflow runs on pushes and pull requests targeting `{{MAIN_BRANCH}}` and
 - `resolve-runner` decides which runner labels downstream jobs should use.
 - The default target comes from `{{CI_RUNNER}}`.
 - Manual `workflow_dispatch` runs can override the target with:
+  - `fargate`
   - `github_hosted`
   - `self_hosted_linux`
   - `self_hosted_linux_arm64`
 - Downstream jobs use `runs-on: ${{ fromJSON(needs.resolve-runner.outputs.runner) }}`.
-- `resolve-runner` also emits `container.options` for self-hosted runs so containerized jobs keep workspace file ownership compatible with the runner user.
+- `fargate` resolves to `[self-hosted, fargate]`; one ephemeral runner task claims one queued job and exits.
 
 ### Smart Skip Logic
 
@@ -29,54 +30,45 @@ The CI workflow runs on pushes and pull requests targeting `{{MAIN_BRANCH}}` and
 
 The aggregate `CI Status Check` job still runs and reports the skip reason, so the skip path is explicit rather than a silent green pass.
 
-### Container Execution Model
+### Fargate-Native Execution Model
 
-All CI jobs except `resolve-runner` execute in the same image:
+Main CI jobs execute directly on the resolved runner:
 
-- `ghcr.io/{{GITHUB_OWNER}}/{{PROJECT_NAME}}-ci:latest`
-- multi-platform manifest: `linux/amd64` and `linux/arm64`
 - checkout path isolation via `path: repo`
-- `safe.directory` configured in every container job
-- no per-job `actions/setup-python`
-- Python matrix jobs call preinstalled interpreters directly (`python3.10`, `python3.11`, `python3.12`)
+- `safe.directory` configured in every job
+- `actions/setup-python` selects the requested Python version
+- dependencies and pinned security tools are installed per job
+
+Fargate runners do not provide nested Docker job containers, so the main workflow must not use a top-level `container:` block. The shared CI image under `infra/ci/` remains available for local checks and non-Fargate runners; its image-publish workflow stays GitHub-hosted because the Fargate runner cannot run Docker-in-Docker builds.
 
 ### Failure Short-Circuiting
 
 - workflow concurrency cancels stale pull-request runs on new pushes
-- `coverage` runs before the Python matrix, so low coverage fails before the full matrix fan-out
-- the Python matrix uses `fail-fast: true`
-- each container job requests workflow cancellation via the Actions API if it fails
+- the Python 3.12 test job enforces coverage in the same run
+- each check job requests workflow cancellation via the Actions API if it fails
 
 ## Job Summary
 
 ### 1. Resolve Runner Target
 
-Purpose: choose the runner labels, container options, CI image reference, and skip mode.
+Purpose: choose the runner labels and skip mode.
 
 ### 2. Lint and Code Quality
 
-Purpose: run black, isort, flake8, and mypy.
+Purpose: run black, isort, flake8, mypy, YAML validation, and Python syntax checks.
 
 Implementation detail:
 - uses a pinned lint-only virtual environment so lint versions stay stable even if the shared image tag moves forward
 
-### 3. Coverage Check
+### 3. Test Python 3.12
 
-Purpose: enforce the `{{COVERAGE_THRESHOLD}}%` coverage gate and publish the HTML coverage artifact.
+Purpose: run pytest, enforce the `{{COVERAGE_THRESHOLD}}%` coverage gate, and publish the HTML coverage artifact.
 
-### 4. Test Python 3.10 / 3.11 / 3.12
+### 4. Security Checks
 
-Purpose: run the correctness matrix after the coverage gate passes.
+Purpose: install pinned bandit and pip-audit versions and run both checks.
 
-### 5. Security Checks
-
-Purpose: run bandit and pip-audit in the shared CI image.
-
-### 6. Validate Configuration
-
-Purpose: validate YAML configuration and Python syntax.
-
-### 7. CI Status Check
+### 5. CI Status Check
 
 Purpose: aggregate job outcomes and publish the final required status, including intentional skip reasons.
 
@@ -86,16 +78,18 @@ The template also includes a dedicated `Secret Scanning` workflow for repository
 
 - triggers on `push`, `pull_request`, and `workflow_dispatch`
 - checks out the full git history with `fetch-depth: 0`
+- runs on an ephemeral `[self-hosted, fargate]` runner
 - installs a pinned `gitleaks` release and verifies its checksum
+- executes the workspace binary directly without `sudo`
 - generates a redacted SARIF report
 - uploads the redacted SARIF artifact on every run
 - attempts a best-effort upload to GitHub code scanning when the repository supports SARIF ingestion
 
-This workflow is separate from `ci.yml` because secret scanning has different runtime and reporting needs than the containerized application checks.
+This workflow is separate from `ci.yml` because secret scanning has different runtime and reporting needs than application checks.
 
-## CI Image Workflow (`.github/workflows/ci-image.yml`)
+## Optional CI Image Workflow (`.github/workflows/ci-image.yml`)
 
-The CI image workflow rebuilds and publishes the shared image when these inputs change:
+The CI image workflow rebuilds and publishes the optional local/self-hosted image when these inputs change:
 
 - `infra/ci/Dockerfile`
 - `requirements.txt`
@@ -145,26 +139,25 @@ gitleaks dir . --no-banner --redact=100
 gitleaks git . --no-banner --redact=100
 ```
 
-## Containerized CI Architecture
+## CI Architecture
 
 ```mermaid
 flowchart LR
     A["push / pull_request / workflow_dispatch"] --> B["resolve-runner"]
     B --> B1{"merged PR push or docs-only diff?"}
     B1 -- Yes --> H["CI Status Check"]
-    B1 -- No --> C["containerized jobs"]
-    C --> D["Coverage Check"]
-    C --> E["Lint / Security / Validate Configuration"]
-    D --> F["Test matrix: Python 3.10 / 3.11 / 3.12"]
+    B1 -- No --> C["native jobs on ephemeral Fargate runners"]
+    C --> D["Test Python 3.12 + coverage"]
+    C --> E["Lint / config validation / security"]
     D --> G["coverage.xml + htmlcov + Codecov"]
     E --> H
-    F --> H
+    D --> H
     G --> H
 
-    I["ci-image.yml"] --> J["Build ghcr.io/{{GITHUB_OWNER}}/{{PROJECT_NAME}}-ci"]
+    I["optional ci-image.yml"] --> J["Build ghcr.io/{{GITHUB_OWNER}}/{{PROJECT_NAME}}-ci on GitHub-hosted runner"]
     J --> K["linux/amd64 + linux/arm64"]
     K --> L["latest + sha tags"]
-    L --> C
+    L --> M["local / persistent self-hosted validation"]
 ```
 
 ## Configuration Files
@@ -172,8 +165,8 @@ flowchart LR
 | File | Purpose |
 |------|---------|
 | `.github/workflows/ci.yml` | Main CI workflow |
-| `.github/workflows/ci-image.yml` | CI image build/publish workflow |
-| `.github/workflows/gitleaks.yml` | Repository secret-scanning workflow |
+| `.github/workflows/ci-image.yml` | Optional CI image build/publish workflow |
+| `.github/workflows/gitleaks.yml` | Fargate repository secret-scanning workflow |
 | `infra/ci/Dockerfile` | Shared CI image definition |
 | `infra/ci/docker-compose.ci.yml` | Local container shell matching CI |
 | `infra/ci/build-and-push.sh` | Manual multi-arch build/push helper |

--- a/docs/CI_RUNNER.md
+++ b/docs/CI_RUNNER.md
@@ -1,10 +1,20 @@
 # CI Runner Operations
 
-This guide documents how the template chooses between GitHub-hosted and self-hosted runners, how the shared CI image acts as the execution contract, and what you need to provision if you want to run CI on your own hardware.
+This guide documents how the template chooses between ephemeral ECS Fargate, GitHub-hosted, and persistent self-hosted runners.
 
 ## When To Use Which Runner
 
-### GitHub-hosted
+### ECS Fargate
+
+Use `fargate` when:
+
+- the repository is authorized on the shared Fargate runner GitHub App
+- you want one isolated, ephemeral runner per job
+- you want normal CI and secret scanning off GitHub-hosted billing
+
+The template defaults to `fargate`. If you do not operate the shared dispatcher, select `github_hosted` when running `setup_template.py`.
+
+### GitHub-hosted fallback
 
 Use `github_hosted` when:
 
@@ -20,19 +30,27 @@ Use `self_hosted_linux` or `self_hosted_linux_arm64` when:
 - you want to reuse a local Docker cache or pre-pulled CI image
 - you need parity with deployment hardware or ARM-specific behavior
 
-## Runner-As-Contract Guidance
+## Runner Contract
 
-The Docker CI image is the contract. The runner should be treated as a thin host that only needs to:
+The main workflow executes natively on the selected runner. The runner must be able to:
 
 - run GitHub Actions jobs
-- run Linux containers
-- pull `ghcr.io/{{GITHUB_OWNER}}/{{PROJECT_NAME}}-ci:latest`
+- run `actions/setup-python`
+- reach PyPI and GitHub to install dependencies and actions
 
-That means:
+Fargate deliberately does not run nested Docker job containers. Each job checks out under `repo/`, selects Python with `actions/setup-python`, and installs the dependencies it needs. The image under `infra/ci/` remains an optional local or persistent-runner tool, not the Fargate execution environment.
 
-- GitHub-hosted CI, self-hosted CI, and local `docker compose` runs all execute the same toolchain
-- "works on my machine" should map to "works in CI" when you validate inside `infra/ci/docker-compose.ci.yml`
-- host-specific setup belongs in runner bootstrap playbooks, not in individual CI jobs
+## Authorize A Repository On The Shared Fargate App
+
+Before changing a repository to `[self-hosted, fargate]`, add it to the shared GitHub App installation. With an owner token and the installation ID:
+
+```bash
+repository_id="$(gh api repos/{{GITHUB_OWNER}}/{{PROJECT_NAME}} --jq .id)"
+gh api -X PUT \
+  "user/installations/<installation-id>/repositories/${repository_id}"
+```
+
+Verify the first workflow run is claimed by a runner named `fargate-<job-id>` before treating activation as complete. A generated repository outside the infrastructure owner's account should use `github_hosted` until it has its own dispatcher and App installation.
 
 ## Workflow Surface
 
@@ -41,24 +59,20 @@ That means:
 - default target: `{{CI_RUNNER}}`
 - manual override via `workflow_dispatch` input `runner_target`
 - supported values:
+  - `fargate`
   - `github_hosted`
   - `self_hosted_linux`
   - `self_hosted_linux_arm64`
 
-Downstream jobs consume:
-
-- `runs-on: ${{ fromJSON(needs.resolve-runner.outputs.runner) }}`
-- `container.options` from `resolve-runner`
-
-For self-hosted runners, the template assumes the runner workspace should remain writable by a non-root user and therefore runs CI containers with an explicit UID:GID mapping.
+Downstream jobs consume `runs-on: ${{ fromJSON(needs.resolve-runner.outputs.runner) }}`. The `Secret Scanning` workflow uses `[self-hosted, fargate]` directly so Gitleaks follows the same runner policy.
 
 ## Register A Self-Hosted Runner
 
-1. Create a Linux host that can run Docker containers.
+1. Create a Linux host that can run GitHub Actions jobs.
 2. Create a GitHub runner registration token for the repository.
 3. Copy and adapt `infra/home-worker/ci_runner_setup.yml` for your environment.
 4. Keep the runner labels aligned with `.github/workflows/ci.yml`.
-5. Optionally pre-pull `ghcr.io/{{GITHUB_OWNER}}/{{PROJECT_NAME}}-ci:latest` after provisioning.
+5. Verify the host can run `actions/setup-python` and install project dependencies.
 
 Suggested baseline labels:
 
@@ -82,17 +96,17 @@ bandit -r {{SOURCE_DIR}}/ -ll
 pip-audit --requirement requirements.txt
 ```
 
-## Bootstrap Checklist For Self-Hosted Linux
+## Bootstrap Checklist For Persistent Self-Hosted Linux
 
-- install Docker Engine and confirm the runner user can access it
 - install the GitHub Actions runner binary for the host architecture
 - register the runner for `https://github.com/{{GITHUB_OWNER}}/{{PROJECT_NAME}}`
 - configure the runner as a persistent service
-- verify the runner can pull `ghcr.io/{{GITHUB_OWNER}}/{{PROJECT_NAME}}-ci:latest`
+- verify Python setup and dependency installation work
 - run a manual `workflow_dispatch` CI job against the self-hosted target
 
 ## Operational Notes
 
 - If you rename CI jobs, update the required status contexts in `scripts/github/branch-protection-config.json`.
 - If you change runner labels, keep `docs/CI_RUNNER.md`, `infra/home-worker/ci_runner_setup.yml`, and `.github/workflows/ci.yml` aligned.
-- If you change the shared toolchain, rebuild the CI image before expecting CI to pick it up.
+- Keep `.github/workflows/gitleaks.yml` on the Fargate labels and avoid `sudo`; the ephemeral runner executes the downloaded binary from its workspace.
+- If you change the optional shared toolchain, rebuild the CI image before using it locally or on a persistent runner.

--- a/docs/CI_RUNNER.md
+++ b/docs/CI_RUNNER.md
@@ -64,7 +64,7 @@ Verify the first workflow run is claimed by a runner named `fargate-<job-id>` be
   - `self_hosted_linux`
   - `self_hosted_linux_arm64`
 
-Downstream jobs consume `runs-on: ${{ fromJSON(needs.resolve-runner.outputs.runner) }}`. The `Secret Scanning` workflow uses `[self-hosted, fargate]` directly so Gitleaks follows the same runner policy.
+The resolver and `Secret Scanning` job use the bootstrap labels selected by `CI_RUNNER` during template setup. Downstream CI jobs consume `runs-on: ${{ fromJSON(needs.resolve-runner.outputs.runner) }}`, allowing a manual dispatch to target another configured runner once the bootstrap runner is available.
 
 ## Register A Self-Hosted Runner
 
@@ -88,7 +88,7 @@ docker build -t {{PROJECT_NAME}}-ci:test -f infra/ci/Dockerfile .
 docker compose -f infra/ci/docker-compose.ci.yml run --rm ci bash
 ```
 
-Inside the container, run the same commands CI uses:
+Inside the container, run checks equivalent to the native CI commands. Tool and base-image versions can differ because GitHub Actions creates fresh per-job Python environments:
 
 ```bash
 python3.12 -m pytest {{TEST_DIR}}/ -v --cov={{SOURCE_DIR}}
@@ -108,5 +108,5 @@ pip-audit --requirement requirements.txt
 
 - If you rename CI jobs, update the required status contexts in `scripts/github/branch-protection-config.json`.
 - If you change runner labels, keep `docs/CI_RUNNER.md`, `infra/home-worker/ci_runner_setup.yml`, and `.github/workflows/ci.yml` aligned.
-- Keep `.github/workflows/gitleaks.yml` on the Fargate labels and avoid `sudo`; the ephemeral runner executes the downloaded binary from its workspace.
+- Keep `.github/workflows/gitleaks.yml` on the configured bootstrap labels and avoid `sudo`; the runner executes the downloaded binary from its workspace.
 - If you change the optional shared toolchain, rebuild the CI image before using it locally or on a persistent runner.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -44,8 +44,8 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Starter skills and local deploy workflow
 
 **[CI_RUNNER.md](CI_RUNNER.md)**
-- Self-hosted runner setup and operations
-- Docker CI image contract and runner-target guidance
+- Fargate App activation and ephemeral-runner operations
+- GitHub-hosted and persistent self-hosted fallback guidance
 
 **[OBSERVABILITY.md](OBSERVABILITY.md)**
 - Structured logging and operator observability patterns
@@ -109,8 +109,8 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 - Post-creation GitHub security features to enable
 
 **[CI_RUNNER.md](CI_RUNNER.md)**
-- GitHub-hosted vs self-hosted runner guidance
-- Docker CI image contract and local parity workflow
+- Fargate, GitHub-hosted, and persistent self-hosted runner guidance
+- Optional local CI-image workflow
 - Runner registration and label alignment notes
 
 **[OBSERVABILITY.md](OBSERVABILITY.md)**
@@ -181,7 +181,7 @@ Welcome to the {{PROJECT_NAME}} documentation. This index provides easy access t
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Technical architecture and design | Developers |
 | [CI.md](CI.md) | CI/CD pipeline and development workflow | Developers |
 | [SECURITY_BASELINE.md](SECURITY_BASELINE.md) | Secret scanning baseline and GitHub security setup | Developers, operators |
-| [CI_RUNNER.md](CI_RUNNER.md) | Self-hosted runner operations and CI image contract | Developers, operators |
+| [CI_RUNNER.md](CI_RUNNER.md) | Fargate activation and CI runner operations | Developers, operators |
 | [OBSERVABILITY.md](OBSERVABILITY.md) | Logging, health, Loki, and operator runbook patterns | Developers, operators |
 | [RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md) | Release deployment automation guide | Developers, operators |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Deployment conventions plus runbook and rollback notes | Developers, operators |

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -4,7 +4,7 @@ This template includes a baseline repository-security setup so new projects get 
 
 ## Included In The Template
 
-- `.github/workflows/gitleaks.yml` scans the full git history on `push`, `pull_request`, and `workflow_dispatch` using an ephemeral `[self-hosted, fargate]` runner.
+- `.github/workflows/gitleaks.yml` scans the full git history on `push`, `pull_request`, and `workflow_dispatch` using the runner selected during template setup (ephemeral Fargate by default).
 - `.pre-commit-config.yaml` includes an official `gitleaks` hook so obvious leaks are caught before they are pushed.
 - `.github/workflows/ci.yml` continues to run `bandit` and `pip-audit` for application-level and dependency-level checks.
 

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -4,11 +4,11 @@ This template includes a baseline repository-security setup so new projects get 
 
 ## Included In The Template
 
-- `.github/workflows/gitleaks.yml` scans the full git history on `push`, `pull_request`, and `workflow_dispatch`.
+- `.github/workflows/gitleaks.yml` scans the full git history on `push`, `pull_request`, and `workflow_dispatch` using an ephemeral `[self-hosted, fargate]` runner.
 - `.pre-commit-config.yaml` includes an official `gitleaks` hook so obvious leaks are caught before they are pushed.
 - `.github/workflows/ci.yml` continues to run `bandit` and `pip-audit` for application-level and dependency-level checks.
 
-The `gitleaks` workflow installs a pinned upstream binary, verifies its SHA-256 checksum, redacts findings in logs, and writes a redacted SARIF report. The workflow always uploads the SARIF file as an artifact and attempts a best-effort upload to GitHub code scanning where that feature is available for the repository.
+The `gitleaks` workflow installs a pinned upstream binary into its workspace, verifies its SHA-256 checksum, redacts findings in logs, and writes a redacted SARIF report. It does not require `sudo`. The workflow always uploads the SARIF file as an artifact and attempts a best-effort upload to GitHub code scanning where that feature is available for the repository.
 
 ## Recommended GitHub Features To Enable
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -152,6 +152,10 @@ After the repository exists on GitHub, review and enable the baseline security f
 
 These features are configured in GitHub, not in the local bootstrap commands above.
 
+### Activate The CI Runner
+
+The template defaults to ephemeral Fargate CI. Before the first workflow run, authorize the repository on the shared runner GitHub App using the `gh` command in [CI_RUNNER.md](CI_RUNNER.md). If the repository cannot use that infrastructure, choose `github_hosted` for `CI_RUNNER` when running `setup_template.py`.
+
 ### Deploy AI Skills
 
 The template ships canonical AI skill sources under `ai-skills/` and a deploy flow that renders them to both Claude and Codex:

--- a/setup_template.py
+++ b/setup_template.py
@@ -68,8 +68,8 @@ TEMPLATE_VARS: Dict[str, Dict[str, str]] = {
         "description": "Development branch name",
     },
     "CI_RUNNER": {
-        "default": "github_hosted",
-        "description": "Default CI runner target (github_hosted, self_hosted_linux, self_hosted_linux_arm64)",
+        "default": "fargate",
+        "description": "Default CI runner target (fargate, github_hosted, self_hosted_linux, self_hosted_linux_arm64)",
     },
     "YEAR": {
         "default": str(datetime.date.today().year),

--- a/setup_template.py
+++ b/setup_template.py
@@ -77,6 +77,13 @@ TEMPLATE_VARS: Dict[str, Dict[str, str]] = {
     },
 }
 
+CI_RUNNER_LABELS: Dict[str, str] = {
+    "fargate": "[self-hosted, fargate]",
+    "github_hosted": "ubuntu-latest",
+    "self_hosted_linux": "[self-hosted, linux]",
+    "self_hosted_linux_arm64": "[self-hosted, linux, arm64]",
+}
+
 # Directories to skip entirely when scanning for template files.
 SKIP_DIRS: set[str] = {
     ".git",
@@ -149,7 +156,14 @@ def collect_variables() -> Dict[str, str]:
         print(f"\n{var_info['description']}")
         values[var_name] = get_input(f"  {var_name}", var_info["default"])
 
+    values["CI_RUNNER_LABELS"] = resolve_ci_runner_labels(values["CI_RUNNER"])
+
     return values
+
+
+def resolve_ci_runner_labels(target: str) -> str:
+    """Return the workflow ``runs-on`` value for a configured CI target."""
+    return CI_RUNNER_LABELS.get(target, CI_RUNNER_LABELS["fargate"])
 
 
 def replace_in_file(file_path: Path, replacements: Dict[str, str]) -> bool:
@@ -205,6 +219,11 @@ def render_template_assignment_markers(content: str, replacements: Dict[str, str
         if pending_var is not None:
             value = replacements.get(pending_var)
             assignment = re.match(r"(?P<prefix>\s*[^#\n=]+=\s*)(?P<current>.*?)(?P<newline>\n?)$", line)
+            if assignment is None:
+                assignment = re.match(
+                    r"(?P<prefix>\s*[A-Za-z0-9_-]+:\s*)(?P<current>.*?)(?P<newline>\n?)$",
+                    line,
+                )
             if assignment is not None and value is not None:
                 rendered_lines.append(f"{assignment.group('prefix')}{value}{assignment.group('newline')}")
             else:

--- a/tests/test_setup_template.py
+++ b/tests/test_setup_template.py
@@ -19,6 +19,7 @@ def test_ci_and_secret_scanning_workflows_support_fargate() -> None:
     assert 'runner=["self-hosted","fargate"]' in ci_workflow
     assert "runs-on: [self-hosted, fargate]" in ci_workflow
     assert "    container:" not in ci_workflow
+    assert '.lint-venv/bin/python -c "' in ci_workflow
     assert "runs-on: [self-hosted, fargate]" in secret_workflow
     assert "./gitleaks git ." in secret_workflow
     assert "sudo " not in secret_workflow

--- a/tests/test_setup_template.py
+++ b/tests/test_setup_template.py
@@ -11,18 +11,44 @@ def test_fargate_is_the_default_ci_runner() -> None:
     assert setup_template.TEMPLATE_VARS["CI_RUNNER"]["default"] == "fargate"
 
 
-def test_ci_and_secret_scanning_workflows_support_fargate() -> None:
+def test_ci_and_secret_scanning_workflows_use_configured_runner() -> None:
     project_root = Path(setup_template.__file__).parent
     ci_workflow = (project_root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     secret_workflow = (project_root / ".github/workflows/gitleaks.yml").read_text(encoding="utf-8")
 
     assert 'runner=["self-hosted","fargate"]' in ci_workflow
+    assert ci_workflow.count("# TEMPLATE_VAR:CI_RUNNER_LABELS") == 1
     assert "runs-on: [self-hosted, fargate]" in ci_workflow
     assert "    container:" not in ci_workflow
     assert '.lint-venv/bin/python -c "' in ci_workflow
+    assert secret_workflow.count("# TEMPLATE_VAR:CI_RUNNER_LABELS") == 1
     assert "runs-on: [self-hosted, fargate]" in secret_workflow
     assert "./gitleaks git ." in secret_workflow
     assert "sudo " not in secret_workflow
+
+
+def test_ci_runner_labels_cover_every_supported_target() -> None:
+    assert setup_template.resolve_ci_runner_labels("fargate") == "[self-hosted, fargate]"
+    assert setup_template.resolve_ci_runner_labels("github_hosted") == "ubuntu-latest"
+    assert setup_template.resolve_ci_runner_labels("self_hosted_linux") == "[self-hosted, linux]"
+    assert setup_template.resolve_ci_runner_labels("self_hosted_linux_arm64") == "[self-hosted, linux, arm64]"
+    assert setup_template.resolve_ci_runner_labels("unknown") == "[self-hosted, fargate]"
+
+
+def test_runner_marker_renders_selected_bootstrap_runner(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "jobs:\n  check:\n    # TEMPLATE_VAR:CI_RUNNER_LABELS\n    runs-on: [self-hosted, fargate]\n",
+        encoding="utf-8",
+    )
+
+    replaced = setup_template.replace_in_file(
+        workflow,
+        {"CI_RUNNER_LABELS": setup_template.resolve_ci_runner_labels("github_hosted")},
+    )
+
+    assert replaced is True
+    assert workflow.read_text(encoding="utf-8") == "jobs:\n  check:\n    runs-on: ubuntu-latest\n"
 
 
 def test_render_template_path_replaces_placeholders() -> None:

--- a/tests/test_setup_template.py
+++ b/tests/test_setup_template.py
@@ -7,6 +7,23 @@ from pathlib import Path
 import setup_template
 
 
+def test_fargate_is_the_default_ci_runner() -> None:
+    assert setup_template.TEMPLATE_VARS["CI_RUNNER"]["default"] == "fargate"
+
+
+def test_ci_and_secret_scanning_workflows_support_fargate() -> None:
+    project_root = Path(setup_template.__file__).parent
+    ci_workflow = (project_root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    secret_workflow = (project_root / ".github/workflows/gitleaks.yml").read_text(encoding="utf-8")
+
+    assert 'runner=["self-hosted","fargate"]' in ci_workflow
+    assert "runs-on: [self-hosted, fargate]" in ci_workflow
+    assert "    container:" not in ci_workflow
+    assert "runs-on: [self-hosted, fargate]" in secret_workflow
+    assert "./gitleaks git ." in secret_workflow
+    assert "sudo " not in secret_workflow
+
+
 def test_render_template_path_replaces_placeholders() -> None:
     rendered = setup_template.render_template_path(
         Path("infra/hetzner/templates/{{PROJECT_NAME}}.service.j2"),


### PR DESCRIPTION
## Summary
- default generated CI to ephemeral ECS Fargate runners
- execute Python checks natively because Fargate does not support nested Docker job containers
- run the existing Gitleaks history scan on Fargate without sudo
- document GitHub App authorization and keep GitHub-hosted fallback support
- add template contract tests for Fargate and secret scanning

## Validation
- 34 tests passed
- all workflow YAML parsed successfully
- pre-commit run --all-files passed, including Gitleaks, Bandit, pip-audit, mypy, and formatting
- repository is authorized on the shared automation-fargate-ci GitHub App